### PR TITLE
chore: migrate to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.x']
+        dotnet-version: ['8.x']
         
     steps:
     - uses: actions/checkout@v3

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Commands/UpsertYandexCalendarExtension.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Commands/UpsertYandexCalendarExtension.cs
@@ -29,7 +29,7 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Commands
                 _protector = protector;
             }
 
-            public async Task<Unit> Handle(Command request, CancellationToken ct)
+            public async Task Handle(Command request, CancellationToken ct)
             {
                 var stored = new StoredSettings(
                     request.Settings.Login,
@@ -53,7 +53,6 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Commands
                 entity.UpdatedAt = DateTime.UtcNow;
 
                 await _repository.UpsertAsync(entity, ct);
-                return Unit.Value;
             }
 
             private record StoredMapping(string Phrase, string IssueKey);

--- a/src/Pet.Jira.Application/Issues/Queries/GetIssueStatuses.cs
+++ b/src/Pet.Jira.Application/Issues/Queries/GetIssueStatuses.cs
@@ -20,16 +20,11 @@ namespace Pet.Jira.Application.Issues.Queries
             public IEnumerable<IssueStatus> IssueStatuses { get; set; }
         }
 
-        public class QueryHandler : IRequestHandler<Query, Model>
+        public class QueryHandler(IIssueDataSource issueDataSource) : IRequestHandler<Query, Model>
         {
-            private readonly IIssueDataSource _issueDataSource;
+            private readonly IIssueDataSource _issueDataSource = issueDataSource;
 
-            public QueryHandler(IIssueDataSource issueDataSource)
-            {
-                _issueDataSource = issueDataSource;
-            }
-
-            public async Task<Model> Handle(
+			public async Task<Model> Handle(
                 Query query,
                 CancellationToken cancellationToken)
             {

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -15,8 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="15.1.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -19,8 +19,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="11.8.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
-    <PackageReference Include="MediatR" Version="11.1.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
   </ItemGroup>

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -17,11 +17,11 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="FluentValidation" Version="11.8.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Pet.Jira.Application/Pet.Jira.Application.csproj
+++ b/src/Pet.Jira.Application/Pet.Jira.Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Pet.Jira.Application/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Application/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Pet.Jira.Application
             services.AddSingleton<IMemoryCache<string, UserTheme>, UserThemeMemoryCache>();
             services.AddSingleton<IMemoryCache<string, UserWorklogFilter>, UserWorklogFilterMemoryCache>();
 
-			services.AddMediatR(Assembly.GetExecutingAssembly());
+			services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
 			services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 			services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 

--- a/src/Pet.Jira.Application/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Application/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Pet.Jira.Application
 			services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 			services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
-			services.AddAutoMapper(Assembly.GetExecutingAssembly());
+			services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()));
 
 			return services;
         }

--- a/src/Pet.Jira.Application/Storage/IStorage.cs
+++ b/src/Pet.Jira.Application/Storage/IStorage.cs
@@ -6,7 +6,7 @@ namespace Pet.Jira.Application.Storage
     public interface IStorage<TKey, TEntity>
     {
         Task<bool> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
-        Task<TEntity> GetValueAsync(TKey key, CancellationToken cancellationToken = default);
+        Task<TEntity?> GetValueAsync(TKey key, CancellationToken cancellationToken = default);
         Task<bool> RemoveAsync(TKey key, CancellationToken cancellationToken = default);
         Task<bool> UpdateAsync(TKey key, TEntity newEntity, CancellationToken cancellationToken = default);
 

--- a/src/Pet.Jira.Domain/Pet.Jira.Domain.csproj
+++ b/src/Pet.Jira.Domain/Pet.Jira.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pet.Jira.Domain/Pet.Jira.Domain.csproj
+++ b/src/Pet.Jira.Domain/Pet.Jira.Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TimeZoneConverter" Version="6.0.1" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalendarSettingsProvider.cs
+++ b/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalendarSettingsProvider.cs
@@ -1,5 +1,6 @@
 using Pet.Jira.Application.Extensions;
 using Pet.Jira.Application.Extensions.YandexCalendar;
+using System.Security.Cryptography;
 using Pet.Jira.Application.Extensions.YandexCalendar.Dto;
 using Pet.Jira.Application.Security;
 using Pet.Jira.Domain.Entities.Extensions;
@@ -31,7 +32,17 @@ namespace Pet.Jira.Infrastructure.Extensions.YandexCalendar
             var stored = JsonSerializer.Deserialize<StoredSettings>(entity.Settings);
             if (stored is null) return null;
 
-            var plainPassword = _protector.Unprotect(stored.AppPasswordEncrypted);
+            string plainPassword;
+            try
+            {
+                plainPassword = _protector.Unprotect(stored.AppPasswordEncrypted);
+            }
+            catch (CryptographicException)
+            {
+                // Stored password was encrypted with a different key (e.g. after app restart or migration).
+                // Treat as missing so the user can re-enter credentials.
+                return null;
+            }
 
             var mappings = stored.IssueMappings?
                 .Select(m => new YandexCalendarIssueMapping(m.Phrase, m.IssueKey))

--- a/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
+++ b/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
@@ -7,26 +7,20 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
     <PackageReference Include="Ical.Net" Version="4.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
     <PackageReference Include="Atlassian.SDK" Version="13.0.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.24" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Pet.Jira.Application\Pet.Jira.Application.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions">
-      <HintPath>C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\6.0.8\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
+++ b/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.24" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.13" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
+++ b/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.System" Version="8.0.1" />
     <PackageReference Include="Ical.Net" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
     <PackageReference Include="Atlassian.SDK" Version="13.0.0" />
-    <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />

--- a/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
+++ b/src/Pet.Jira.Infrastructure/Pet.Jira.Infrastructure.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ namespace Pet.Jira.Infrastructure
 			services.AddDataProtection()
 				.PersistKeysToFileSystem(new System.IO.DirectoryInfo(
 					System.IO.Path.Combine(System.AppContext.BaseDirectory, "DataProtection-Keys")))
-				.SetApplicationName("PetJira");
+				.SetApplicationName("Chronos");
 			services.AddSingleton<ISecretProtector, DataProtectionSecretProtector>();
 
 			services.AddHttpClient<IYandexCalendarService, YandexCalDavService>();

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -82,7 +82,7 @@ namespace Pet.Jira.Infrastructure
                 .AddJiraHealthCheck()
                 .AddProcessAllocatedMemoryHealthCheck(
                     maximumMegabytesAllocated: 300,
-                    tags: new[] { "system" });
+                    tags: ["system"]);
             return builder;
         }
     }

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Pet.Jira.Application.Articles;
@@ -62,7 +63,10 @@ namespace Pet.Jira.Infrastructure
 
 			services.AddTransient<IUserRepository, UserRepository>();
 
-			services.AddDataProtection();
+			services.AddDataProtection()
+				.PersistKeysToFileSystem(new System.IO.DirectoryInfo(
+					System.IO.Path.Combine(System.AppContext.BaseDirectory, "DataProtection-Keys")))
+				.SetApplicationName("PetJira");
 			services.AddSingleton<ISecretProtector, DataProtectionSecretProtector>();
 
 			services.AddHttpClient<IYandexCalendarService, YandexCalDavService>();

--- a/src/Pet.Jira.Infrastructure/Storage/BaseStorage.cs
+++ b/src/Pet.Jira.Infrastructure/Storage/BaseStorage.cs
@@ -55,7 +55,7 @@ namespace Pet.Jira.Infrastructure.Storage
             }
             if (entity != null)
             {
-                await UpdateAsync(key, entity);
+                await UpdateAsync(key, entity, cancellationToken);
             }
         }
 

--- a/src/Pet.Jira.Web/Components/Extensions/ExtensionsPage.razor
+++ b/src/Pet.Jira.Web/Components/Extensions/ExtensionsPage.razor
@@ -1,4 +1,3 @@
-@using Pet.Jira.Web.Components.Extensions
 @using Pet.Jira.Web.Components.Extensions.YandexCalendar
 
 <div class="extv-glow__grid">

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarExtensionCard.razor
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarExtensionCard.razor
@@ -25,7 +25,7 @@
         }
         else
         {
-            <MudSwitch T="bool" Checked="_isEnabled" Color="Color.Success" CheckedChanged="OnToggleChangedAsync" />
+            <MudSwitch T="bool" Value="_isEnabled" Color="Color.Success" ValueChanged="OnToggleChangedAsync" />
             <MudSpacer />
             <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small"
                        StartIcon="@Icons.Material.Filled.Tune"

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarExtensionCard.razor.cs
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarExtensionCard.razor.cs
@@ -66,7 +66,7 @@ namespace Pet.Jira.Web.Components.Extensions.YandexCalendar
             var dialog = await DialogService.ShowAsync<YandexCalendarSettingsDialog>(
                 "Яндекс Календарь — настройки", parameters);
             var result = await dialog.Result;
-            if (!result.Cancelled)
+            if (!result.Canceled)
             {
                 _hasSettings = result.Data is YandexCalendarSettingsDto;
                 _isEnabled = _hasSettings;

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor
@@ -57,10 +57,10 @@
 
         @if (_excludedPhrases.Count > 0)
         {
-            <MudChipSet AllClosable="true" OnClose="OnChipClose" Class="mt-2 ycd-chips">
+            <MudChipSet T="string" AllClosable="true" OnClose="OnChipClose" Class="mt-2 ycd-chips">
                 @foreach (var phrase in _excludedPhrases)
                 {
-                    <MudChip Text="@phrase" Size="Size.Small" Color="Color.Default" />
+                    <MudChip T="string" Value="@phrase" Text="@phrase" Size="Size.Small" Color="Color.Default" />
                 }
             </MudChipSet>
         }

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
@@ -40,8 +40,8 @@ namespace Pet.Jira.Web.Components.Extensions.YandexCalendar
             {
                 _login = ExistingSettings.Login;
                 _appPassword = ExistingSettings.AppPassword;
-                _excludedPhrases = new List<string>(ExistingSettings.ExcludedPhrases);
-                _issueMappings = new List<YandexCalendarIssueMapping>(ExistingSettings.IssueMappings);
+                _excludedPhrases = [.. ExistingSettings.ExcludedPhrases];
+                _issueMappings = [.. ExistingSettings.IssueMappings];
             }
         }
 

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
@@ -14,7 +14,7 @@ namespace Pet.Jira.Web.Components.Extensions.YandexCalendar
 {
     public partial class YandexCalendarSettingsDialog : ComponentBase
     {
-        [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = default!;
+        [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
         [Parameter] public string Username { get; set; } = string.Empty;
         [Parameter] public YandexCalendarSettingsDto? ExistingSettings { get; set; }

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
@@ -85,7 +85,7 @@ namespace Pet.Jira.Web.Components.Extensions.YandexCalendar
             if (e.Key == "Enter") AddPhrase();
         }
 
-        private void OnChipClose(MudChip chip) => _excludedPhrases.Remove(chip.Text);
+        private void OnChipClose(MudChip<string> chip) => _excludedPhrases.Remove(chip.Text);
 
         private void AddMapping()
         {

--- a/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Extensions/YandexCalendar/YandexCalendarSettingsDialog.razor.cs
@@ -109,7 +109,7 @@ namespace Pet.Jira.Web.Components.Extensions.YandexCalendar
 
         private async Task Save()
         {
-            await _form.Validate();
+            await _form.ValidateAsync();
             if (!_form.IsValid) return;
 
             var settings = new YandexCalendarSettingsDto(

--- a/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor
+++ b/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor
@@ -11,7 +11,6 @@
 
 <MudElement Class="d-flex flex-wrap gap-4 border-none">
     <MudMarkdown Value="@Value"
-                 TableCellMinWidth="100"
                  OverrideLinkUrl="OverrideLink"
                  CodeBlockTheme="CodeBlockTheme.DraculaBase16" />
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor
+++ b/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor
@@ -1,6 +1,4 @@
-﻿@using Markdig.Syntax.Inlines
-
-<style>
+﻿<style>
     .mud-markdown-body p {
         margin-bottom: 0em !important;
         text-align: left !important;
@@ -10,7 +8,5 @@
 </style>
 
 <MudElement Class="d-flex flex-wrap gap-4 border-none">
-    <MudMarkdown Value="@Value"
-                 OverrideLinkUrl="OverrideLink"
-                 CodeBlockTheme="CodeBlockTheme.DraculaBase16" />
+    <MudMarkdown Value="@Value" />
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor.cs
+++ b/src/Pet.Jira.Web/Components/Markdown/ComponentMarkdownViewer.razor.cs
@@ -1,5 +1,4 @@
-﻿using Markdig.Syntax.Inlines;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Pet.Jira.Web.Shared;
 using System;
 using System.Threading.Tasks;
@@ -26,6 +25,5 @@ namespace Pet.Jira.Web.Components.Markdown
             }            
         }
 
-        private static string OverrideLink(LinkInline x) => x.Url;
     }
 }

--- a/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor
+++ b/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor
@@ -2,7 +2,6 @@
 
 <MudElement Class="d-flex flex-wrap gap-4 border-none">
     <MudMarkdown Value="@Value"
-                 TableCellMinWidth="100"
                  OverrideLinkUrl="OverrideLink"
                  CodeBlockTheme="CodeBlockTheme.DraculaBase16" />
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor
+++ b/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor
@@ -1,7 +1,3 @@
-﻿@using Markdig.Syntax.Inlines
-
-<MudElement Class="d-flex flex-wrap gap-4 border-none">
-    <MudMarkdown Value="@Value"
-                 OverrideLinkUrl="OverrideLink"
-                 CodeBlockTheme="CodeBlockTheme.DraculaBase16" />
+﻿<MudElement Class="d-flex flex-wrap gap-4 border-none">
+    <MudMarkdown Value="@Value" />
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor.cs
+++ b/src/Pet.Jira.Web/Components/Markdown/MarkdownViewer.razor.cs
@@ -1,5 +1,4 @@
-﻿using Markdig.Syntax.Inlines;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Pet.Jira.Web.Shared;
 using System;
 using System.Threading.Tasks;
@@ -26,6 +25,5 @@ namespace Pet.Jira.Web.Components.Markdown
             }            
         }
 
-        private static string OverrideLink(LinkInline x) => x.Url;
     }
 }

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarEventItem.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarEventItem.razor
@@ -36,11 +36,12 @@
         }
         else
         {
-            <MudIconButton Size="Size.Small"
-                           Icon="@Icons.Material.Filled.Add"
-                           Color="Color.Success"
-                           Title="Залогировать"
-                           OnClick="@(() => OnLogPressed.InvokeAsync(Entity))" />
+            <MudTooltip Text="Залогировать">
+                <MudIconButton Size="Size.Small"
+                               Icon="@Icons.Material.Filled.Add"
+                               Color="Color.Success"
+                               OnClick="@(() => OnLogPressed.InvokeAsync(Entity))" />
+            </MudTooltip>
         }
     </MudElement>
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Worklogs/EstimatedActualWorklogItem.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/EstimatedActualWorklogItem.razor
@@ -1,6 +1,6 @@
 ﻿<MudElement Class="gap-2 d-flex flex-wrap border-none align-center">
     <MudElement Class="flex-auto d-flex gap-1 align-center" Style="width: 150px">
-        <MudPaper Class="flex-none" Width="134px" Elevation="0" />
+        <MudPaper Class="flex-none" Width="124px" Elevation="0" />
         <MudElement Class="pl-2 pet-not-display-on-600">
             <MudButton Href="@Entity.Issue.Link"
                        Size="Size.Small"

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
@@ -1,6 +1,5 @@
-@using Pet.Jira.Web.Common
-@using Pet.Jira.Application.Extensions.YandexCalendar.Dto
 @using MudBlazor
+@using Pet.Jira.Web.Common
 
 <tr class="pet-table-summary-tr">
     <td>

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayChip.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayChip.razor
@@ -1,4 +1,4 @@
-﻿<MudChip Color="@Color" Size=@Size Variant=@Variant Label="true">
+﻿<MudChip T="string" Color="@Color" Size=@Size Variant=@Variant Label="true">
     @if (!string.IsNullOrEmpty(@Caption))
     {
         <b class="pet-not-display-on-480">@Caption: </b>

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
@@ -107,7 +107,7 @@ namespace Pet.Jira.Web.Components.Worklogs
             }
         }
 
-        private async Task<IEnumerable<Issue>> SearchIssuesAsync(string value)
+        private async Task<IEnumerable<Issue>> SearchIssuesAsync(string value, System.Threading.CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
@@ -136,7 +136,7 @@ namespace Pet.Jira.Web.Components.Worklogs
 
         private async Task SubmitAsync()
         {
-            await _form.Validate();
+            await _form.ValidateAsync();
             if (!_form.IsValid)
                 return;
 

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
@@ -114,10 +114,10 @@ namespace Pet.Jira.Web.Components.Worklogs
                 if (!string.IsNullOrWhiteSpace(value)
 					&& value.IsJiraKey())
                 {
-                    var issue = await IssueDataSource.GetIssueAsync(value);
+                    var issue = await IssueDataSource.GetIssueAsync(value, cancellationToken);
                     return issue is null
-                        ? Array.Empty<Issue>()
-                        : new[] { issue };
+                        ? []
+						: new[] { issue };
 				}
                 else
                 {

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor.cs
@@ -26,7 +26,7 @@ namespace Pet.Jira.Web.Components.Worklogs
         [Parameter] public string Label { get; set; } = "Default";
 
         [CascadingParameter] public ErrorHandler ErrorHandler { get; set; }
-        [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+        [CascadingParameter] IMudDialogInstance MudDialog { get; set; }
 
         [Inject] private IMemoryCache<string, Issue> IssueCache { get; set; }
 		[Inject] private IIssueDataSource IssueDataSource { get; set; }

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor.cs
@@ -94,7 +94,7 @@ namespace Pet.Jira.Web.Components.Worklogs
             await _filterStorage.UpdateAsync(user?.Key, filter);
         }
 
-        private async Task<IEnumerable<IssueStatus>> SearchIssueStatuses(string value)
+        private async Task<IEnumerable<IssueStatus>> SearchIssueStatuses(string value, System.Threading.CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor.cs
@@ -98,7 +98,7 @@ namespace Pet.Jira.Web.Components.Worklogs
         {
             try
             {
-                var result = await Mediator.Send(new GetIssueStatuses.Query());
+                var result = await Mediator.Send(new GetIssueStatuses.Query(), cancellationToken);
 
                 if (string.IsNullOrEmpty(value)
                     || value.Equals(_model.Filter.IssueStatus?.Name, StringComparison.InvariantCultureIgnoreCase))

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogTimeRange.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogTimeRange.razor
@@ -1,4 +1,4 @@
-﻿<MudChip Color="@Color" Size="Size.Small" Variant="@Variant" Label="true">
+﻿<MudChip T="string" Color="@Color" Size="Size.Small" Variant="@Variant" Label="true">
     @StartDate.ToString(_defaultTimeFormat) <MudIcon Icon="@Icons.Material.Filled.ArrowRightAlt" Size="Size.Small" /> @CompleteDate.ToString(_defaultTimeFormat)
 </MudChip>
 

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -22,8 +22,7 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.24">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -36,7 +35,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Thinktecture.Blazor.AsyncClipboard" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -25,8 +25,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor" Version="7.15.0" />
-    <PackageReference Include="MudBlazor.Markdown" Version="7.8.0" />
+    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="MudBlazor.Markdown" Version="9.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>3a21bd1f-a675-4630-b374-69f562af1251</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -25,8 +25,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor" Version="6.1.8" />
-    <PackageReference Include="MudBlazor.Markdown" Version="0.1.0" />
+    <PackageReference Include="MudBlazor" Version="7.15.0" />
+    <PackageReference Include="MudBlazor.Markdown" Version="7.8.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -20,8 +20,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="MediatR" Version="11.1.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>annotations</Nullable>
     <UserSecretsId>3a21bd1f-a675-4630-b374-69f562af1251</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Pet.Jira.Web/Pet.Jira.Web.csproj
+++ b/src/Pet.Jira.Web/Pet.Jira.Web.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="6.0.5" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
-    <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -27,12 +27,12 @@
     </PackageReference>
     <PackageReference Include="MudBlazor" Version="6.1.8" />
     <PackageReference Include="MudBlazor.Markdown" Version="0.1.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Thinktecture.Blazor.AsyncClipboard" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
   </ItemGroup>

--- a/src/Pet.Jira.Web/Shared/MainLayout.razor
+++ b/src/Pet.Jira.Web/Shared/MainLayout.razor
@@ -20,19 +20,26 @@
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" OnClick="@ToggleDrawer" />
             <MudText Typo="Typo.h6" Class="ml-3 pet-not-display-on-480">Jira Copilot</MudText>
             <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/tolmachev-pravo/Pet.Jira" Target="_blank" />
-            <MudToggleIconButton Toggled="@_model.Theme.IsDarkMode"
-                                 Icon="@Icons.Material.Filled.LightMode"
-                                 Title="Light mode"
-                                 Color="@Color.Inherit"
-                                 ToggledIcon="@Icons.Material.Filled.DarkMode"
-                                 ToggledTitle="Dark mode"
-                                 ToggledColor="@Color.Inherit"
-                                 ToggledChanged="@ToggleThemeAsync"/>
+            <MudTooltip Text="@(_model.Theme.IsDarkMode ? "Dark mode" : "Light mode")">
+                <MudToggleIconButton Toggled="@_model.Theme.IsDarkMode"
+                                     Icon="@Icons.Material.Filled.LightMode"
+                                     Color="@Color.Inherit"
+                                     ToggledIcon="@Icons.Material.Filled.DarkMode"
+                                     ToggledColor="@Color.Inherit"
+                                     ToggledChanged="@ToggleThemeAsync"/>
+            </MudTooltip>
             <MudSpacer></MudSpacer>
             <AuthorizeView>
                 <Authorized>
-                    <MudAvatar Size="Size.Small" Color="Color.Primary" Image="@_model.Profile.Avatar">
-                        <MudIcon Icon="@Icons.Material.Rounded.AccountCircle" />
+                    <MudAvatar Size="Size.Small" Color="Color.Primary">
+                        @if (!string.IsNullOrEmpty(_model.Profile.Avatar))
+                        {
+                            <img src="@_model.Profile.Avatar" alt="avatar" />
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Rounded.AccountCircle" />
+                        }
                     </MudAvatar>
                     <MudElement Class="mr-2 ml-2">@context.User.Identity.Name</MudElement>
                     <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="Logout" Color="Color.Inherit" Href="/logout" Size="Size.Small" />

--- a/src/Pet.Jira.Web/Shared/MainLayout.razor
+++ b/src/Pet.Jira.Web/Shared/MainLayout.razor
@@ -2,7 +2,7 @@
 
 <MudDialogProvider MaxWidth="MaxWidth.Medium"
                    CloseButton="true"
-                   DisableBackdropClick="true"
+                   BackdropClick="false"
                    Position="DialogPosition.Center"
                    CloseOnEscapeKey="true" />
 <MudSnackbarProvider />

--- a/src/Pet.Jira.Web/Shared/MainLayout.razor
+++ b/src/Pet.Jira.Web/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@inherits LayoutComponentBase
 
+<MudPopoverProvider />
 <MudDialogProvider MaxWidth="MaxWidth.Medium"
                    CloseButton="true"
                    BackdropClick="false"

--- a/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/GetYandexCalendarEventsHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/GetYandexCalendarEventsHandlerTests.cs
@@ -109,7 +109,7 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
 
             var mappings = new List<YandexCalendarIssueMapping>
             {
-                new YandexCalendarIssueMapping("Core Daily Sync", "CASEM-73656")
+                new("Core Daily Sync", "CASEM-73656")
             };
             var dto = new YandexCalendarSettingsDto("user@yandex.ru", "pw", new List<string>(), mappings);
             _settingsMock.Setup(s => s.GetSettingsAsync("alice", CancellationToken.None))

--- a/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/UpsertYandexCalendarExtensionHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/UpsertYandexCalendarExtensionHandlerTests.cs
@@ -27,8 +27,8 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
 
         [Test]
         public async Task Handle_EncryptsPasswordBeforeSaving()
-        {
-            _protectorMock.Setup(p => p.Protect("plainpw")).Returns("encpw");
+		{
+			_protectorMock.Setup(p => p.Protect("plainpw")).Returns("encpw");
 
             UserExtension? saved = null;
             _repoMock.Setup(r => r.UpsertAsync(It.IsAny<UserExtension>(), CancellationToken.None))
@@ -41,18 +41,21 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
             await handler.Handle(
                 new UpsertYandexCalendarExtension.Command(
                     "alice",
-                    new YandexCalendarSettingsDto("user@yandex.ru", "plainpw", new List<string>(), new List<YandexCalendarIssueMapping>()),
+                    new YandexCalendarSettingsDto("user@yandex.ru", "plainpw", [], []),
                     IsEnabled: true),
                 CancellationToken.None);
 
             Assert.That(saved, Is.Not.Null);
             var settings = JsonSerializer.Deserialize<StoredSettingsHelper>(saved!.Settings)!;
-            Assert.That(settings.Login, Is.EqualTo("user@yandex.ru"));
-            Assert.That(settings.AppPasswordEncrypted, Is.EqualTo("encpw"));
-            Assert.That(saved.IsEnabled, Is.True);
-            Assert.That(saved.Username, Is.EqualTo("alice"));
-        }
+			Assert.Multiple(() =>
+			{
+				Assert.That(settings.Login, Is.EqualTo("user@yandex.ru"));
+				Assert.That(settings.AppPasswordEncrypted, Is.EqualTo("encpw"));
+				Assert.That(saved.IsEnabled, Is.True);
+				Assert.That(saved.Username, Is.EqualTo("alice"));
+			});
+		}
 
-        private record StoredSettingsHelper(string Login, string AppPasswordEncrypted);
+		private record StoredSettingsHelper(string Login, string AppPasswordEncrypted);
     }
 }

--- a/tests/Pet.Jira.UnitTests/Application/Time/TimeProviderTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Time/TimeProviderTests.cs
@@ -9,7 +9,7 @@ namespace Pet.Jira.UnitTests.Application.Time
         [SetUp]
         public void Setup()
         {
-            _timeProvider = new TimeProvider();
+            _timeProvider = new Pet.Jira.Application.Time.TimeProvider();
         }
 
         [Test]

--- a/tests/Pet.Jira.UnitTests/Application/Time/TimeProviderTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Time/TimeProviderTests.cs
@@ -23,7 +23,7 @@ namespace Pet.Jira.UnitTests.Application.Time
             var result = _timeProvider.ConvertToUserTimezone(dateTime, userTimeZone);
 
             // Assert
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Pet.Jira.UnitTests.Application.Time
             var result = _timeProvider.ConvertToServerTimezone(dateTime, userTimeZone);
 
             // Assert
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]

--- a/tests/Pet.Jira.UnitTests/Application/Worklogs/WorklogMatchingTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Worklogs/WorklogMatchingTests.cs
@@ -32,7 +32,7 @@ namespace Pet.Jira.UnitTests.Application.Worklogs
 
 			// Act
 			// Assert
-			Assert.DoesNotThrow(() => WorklogMatching.Match(parents, children));
+			Assert.That(() => WorklogMatching.Match(parents, children), Throws.Nothing);
 		}
 
 		[Test]
@@ -47,7 +47,7 @@ namespace Pet.Jira.UnitTests.Application.Worklogs
 
 			// Act
 			// Assert
-			Assert.DoesNotThrow(() => WorklogMatching.Match(parents, children));
+			Assert.That(() => WorklogMatching.Match(parents, children), Throws.Nothing);
 		}
 
 		[Test]
@@ -62,7 +62,7 @@ namespace Pet.Jira.UnitTests.Application.Worklogs
 
 			// Act
 			// Assert
-			Assert.DoesNotThrow(() => WorklogMatching.Match(parents, children));
+			Assert.That(() => WorklogMatching.Match(parents, children), Throws.Nothing);
 		}
 
 		[Test]

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Jira/JiraIssueDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Jira/JiraIssueDataSourceTests.cs
@@ -154,7 +154,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Jira
         [TestCase("5", null)]
         [TestCase("6", "https://unit-test.com/6")]
         [TestCase("7", "https://unit-test.com/7-2")]
-        public async Task GetIssueOpenPullRequestUrlAsync_Should_BeCorrect(string identifier, string expected)
+        public async Task GetIssueOpenPullRequestUrlAsync_Should_BeCorrect(string identifier, string? expected)
         {
             // Arrange
             var query = new Pet.Jira.Application.Issues.Queries.GetIssueOpenPullRequestUrl.Query

--- a/tests/Pet.Jira.UnitTests/Infrastructure/TextBuilder/HtmlTextBuilderTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/TextBuilder/HtmlTextBuilderTests.cs
@@ -18,7 +18,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.TextBuilder
         [TestCase(null, "site url", $"<a href=\"\">site url</a> ")]
         [TestCase("https://localhost.ru", null, $"<a href=\"https://localhost.ru\"></a> ")]
         [TestCase(null, null, $"<a href=\"\"></a> ")]
-        public void AddLink_Should_BeCorrect(string href, string value, string expected)
+        public void AddLink_Should_BeCorrect(string? href, string? value, string expected)
         {
             // Arrange
             // Act
@@ -34,7 +34,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.TextBuilder
         [TestCase("text ", "text")]
         [TestCase(" ", "")]
         [TestCase(" ", null)]
-        public void AddText_Should_BeCorrect(string expected, string text, params TextOption[] options)
+        public void AddText_Should_BeCorrect(string expected, string? text, params TextOption[] options)
         {
             // Arrange
             // Act

--- a/tests/Pet.Jira.UnitTests/Infrastructure/TextBuilder/MarkdownTextBuilderTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/TextBuilder/MarkdownTextBuilderTests.cs
@@ -18,7 +18,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.TextBuilder
         [TestCase(null, "site url", $"[site url]() ")]
         [TestCase("https://localhost.ru", null, $"[](https://localhost.ru) ")]
         [TestCase(null, null, $"[]() ")]
-        public void AddLink_Should_BeCorrect(string href, string value, string expected)
+        public void AddLink_Should_BeCorrect(string? href, string? value, string expected)
         {
             // Arrange
             // Act
@@ -34,7 +34,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.TextBuilder
         [TestCase("text ", "text")]
         [TestCase(" ", "")]
         [TestCase(" ", null)]
-        public void AddText_Should_BeCorrect(string expected, string text, params TextOption[] options)
+        public void AddText_Should_BeCorrect(string expected, string? text, params TextOption[] options)
         {
             // Arrange
             // Act

--- a/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
+++ b/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
+++ b/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
@@ -12,14 +12,14 @@
     <PackageReference Include="Ical.Net" Version="4.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
+++ b/tests/Pet.Jira.UnitTests/Pet.Jira.UnitTests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ical.Net" Version="4.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />


### PR DESCRIPTION
## Миграция .NET 6 → .NET 8

### Ядро
- \`TargetFramework\` → \`net8.0\` во всех проектах
- CI (\`dotnet.yml\`): \`dotnet-version\` \`6.x\` → \`8.x\`

### Пакеты
- **Microsoft.\*** и ASP.NET Core → \`8.0.0\`
- **MediatR** \`11\` → \`12.4.1\`: убран \`MediatR.Extensions\`, обновлена регистрация (\`RegisterServicesFromAssembly\`), void-handlers возвращают \`Task\` вместо \`Task<Unit>\`
- **AutoMapper** \`12\` → \`15.1.3\`: убран \`AutoMapper.Extensions\`, обновлена регистрация (\`cfg.AddMaps\`)
- **MudBlazor** \`6\` → \`9.5.0\`: исправлены breaking changes (см. ниже)
- **NUnit** \`3\` → \`4\`: \`Assert.DoesNotThrow\` → \`Throws.Nothing\`, \`Assert.IsNull\` → \`Is.Null\`, nullable TestCase params
- Serilog, HealthChecks, Blazored.LocalStorage — до актуальных версий под .NET 8

### MudBlazor 6 → 9 breaking changes
- Добавлен \`<MudPopoverProvider />\` в \`MainLayout.razor\`
- \`DisableBackdropClick\` → \`BackdropClick="false"\` на \`MudDialogProvider\`
- \`MudDialogInstance\` → \`IMudDialogInstance\` в dialog code-behind
- \`MudIconButton Title\` → обёртка \`<MudTooltip>\`
- \`MudMarkdown\`: убраны параметры \`TableCellMinWidth\`, \`OverrideLinkUrl\`, \`CodeBlockTheme\` (удалены в v9)
- \`MudForm.Validate()\` → \`ValidateAsync()\`
- \`DialogResult.Cancelled\` → \`Canceled\`

### DataProtection
- \`PersistKeysToFileSystem\` — ключи сохраняются между перезапусками приложения
- Graceful \`CryptographicException\` в \`YandexCalendarSettingsProvider\` — при невалидном ключе возвращает \`null\` вместо краша

### Качество кода
- \`<Nullable>annotations</Nullable>\` во всех проектах — устранены CS8632 warnings
- \`IStorage.GetValueAsync\` → \`Task<TEntity?>\` (честная сигнатура: может вернуть null)
- Primary constructors, collection expressions, передача \`CancellationToken\` там где пропустили
- \`Assert.Multiple\` в unit-тестах

### Тесты
79/79 тестов проходят ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)