### PR TITLE
feat: add GET and DELETE endpoints to ArticlesController

### DIFF
--- a/src/Pet.Jira.Application/Articles/Commands/DeleteArticle/DeleteArticleCommand.cs
+++ b/src/Pet.Jira.Application/Articles/Commands/DeleteArticle/DeleteArticleCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using System;
+
+namespace Pet.Jira.Application.Articles.Commands.DeleteArticle
+{
+    public class DeleteArticleCommand : IRequest<bool>
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Pet.Jira.Application/Articles/Commands/DeleteArticle/DeleteArticleCommandHandler.cs
+++ b/src/Pet.Jira.Application/Articles/Commands/DeleteArticle/DeleteArticleCommandHandler.cs
@@ -1,0 +1,22 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Articles.Commands.DeleteArticle
+{
+    public class DeleteArticleCommandHandler : IRequestHandler<DeleteArticleCommand, bool>
+    {
+        private readonly IArticleRepository _repository;
+
+        public DeleteArticleCommandHandler(
+            IArticleRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<bool> Handle(DeleteArticleCommand request, CancellationToken cancellationToken)
+        {
+            return await _repository.DeleteAsync(request.Id, cancellationToken);
+        }
+    }
+}

--- a/src/Pet.Jira.Application/Articles/IArticleRepository.cs
+++ b/src/Pet.Jira.Application/Articles/IArticleRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Pet.Jira.Application.Articles.Commands.CreateArticle;
 using Pet.Jira.Domain.Entities.Blog;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,5 +9,6 @@ namespace Pet.Jira.Application.Articles
     public interface IArticleRepository
     {
         Task<Article> AddAsync(CreateArticleCommand article, CancellationToken cancellationToken = default);
+        Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Pet.Jira.Infrastructure/Articles/ArticleRepository.cs
+++ b/src/Pet.Jira.Infrastructure/Articles/ArticleRepository.cs
@@ -34,5 +34,16 @@ namespace Pet.Jira.Infrastructure.Articles
 
             return articleEntity;
         }
+
+        public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var entity = await _dbContext.Articles.FindAsync(new object[] { id }, cancellationToken);
+            if (entity == null)
+                return false;
+
+            _dbContext.Articles.Remove(entity);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return true;
+        }
     }
 }

--- a/src/Pet.Jira.Infrastructure/Articles/ArticleRepository.cs
+++ b/src/Pet.Jira.Infrastructure/Articles/ArticleRepository.cs
@@ -37,7 +37,7 @@ namespace Pet.Jira.Infrastructure.Articles
 
         public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
-            var entity = await _dbContext.Articles.FindAsync(new object[] { id }, cancellationToken);
+            var entity = await _dbContext.Articles.FindAsync(new object?[] { id }, cancellationToken);
             if (entity == null)
                 return false;
 

--- a/src/Pet.Jira.Web/Controllers/ArticlesController.cs
+++ b/src/Pet.Jira.Web/Controllers/ArticlesController.cs
@@ -1,7 +1,9 @@
-﻿using MediatR;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Pet.Jira.Application.Articles.Commands.CreateArticle;
+using Pet.Jira.Application.Articles.Commands.DeleteArticle;
 using Pet.Jira.Application.Articles.Queries.GetArticles;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,25 +11,45 @@ using System.Threading.Tasks;
 namespace Pet.Jira.Web.Controllers
 {
     [ApiController]
-	[Route("api/[controller]")]
-	public class ArticlesController : ControllerBase
-	{
-		private readonly IMediator _mediator;
+    [Route("api/[controller]")]
+    public class ArticlesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
 
-		public ArticlesController(
-			IMediator mediator)
-		{
-			_mediator = mediator;
-		}
+        public ArticlesController(
+            IMediator mediator)
+        {
+            _mediator = mediator;
+        }
 
-		[HttpPost]
-		public async Task<ActionResult<object>> Create(
-			CreateArticleCommand article,
-			CancellationToken cancellationToken = default)
-		{
-			var articleId = await _mediator.Send(article, cancellationToken);
-			var articles = await _mediator.Send(new GetArticlesQuery(), cancellationToken);
-			return articles.First(entity => entity.Id == articleId);
-		}
-	}
+        [HttpPost]
+        public async Task<ActionResult<object>> Create(
+            CreateArticleCommand article,
+            CancellationToken cancellationToken = default)
+        {
+            var articleId = await _mediator.Send(article, cancellationToken);
+            var articles = await _mediator.Send(new GetArticlesQuery(), cancellationToken);
+            return articles.First(entity => entity.Id == articleId);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<object>> GetAll(
+            CancellationToken cancellationToken = default)
+        {
+            var articles = await _mediator.Send(new GetArticlesQuery(), cancellationToken);
+            return Ok(articles);
+        }
+
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> Delete(
+            Guid id,
+            CancellationToken cancellationToken = default)
+        {
+            var deleted = await _mediator.Send(new DeleteArticleCommand { Id = id }, cancellationToken);
+            if (!deleted)
+                return NotFound();
+
+            return NoContent();
+        }
+    }
 }

--- a/tests/Pet.Jira.UnitTests/Application/Articles/Commands/DeleteArticleCommandHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Articles/Commands/DeleteArticleCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using Moq;
+using Pet.Jira.Application.Articles;
+using Pet.Jira.Application.Articles.Commands.DeleteArticle;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Application.Articles.Commands
+{
+    [TestFixture]
+    public class DeleteArticleCommandHandlerTests
+    {
+        private DeleteArticleCommandHandler _handler;
+        private Mock<IArticleRepository> _repository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repository = new Mock<IArticleRepository>();
+            _handler = new DeleteArticleCommandHandler(_repository.Object);
+        }
+
+        [Test]
+        public async Task Handle_Should_ReturnTrue_When_ArticleExists()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            _repository
+                .Setup(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _handler.Handle(new DeleteArticleCommand { Id = id }, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            _repository.Verify(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Handle_Should_ReturnFalse_When_ArticleNotFound()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            _repository
+                .Setup(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _handler.Handle(new DeleteArticleCommand { Id = id }, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Application/Articles/Commands/DeleteArticleCommandHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Articles/Commands/DeleteArticleCommandHandlerTests.cs
@@ -51,6 +51,7 @@ namespace Pet.Jira.UnitTests.Application.Articles.Commands
 
             // Assert
             Assert.That(result, Is.False);
+            _repository.Verify(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added GET /api/articles - returns list of all articles (200 OK)
- Added DELETE /api/articles/{id} - hard delete by ID (204 / 404)
- Added DeleteArticleCommand + handler (CQRS/MediatR pattern)
- Added unit tests for DeleteArticleCommandHandler

## Test Plan
- All 81 unit tests pass