### PR TITLE
feat: proposed worklog time for events

### DIFF
--- a/src/Pet.Jira.Application/Events/IDayWorklogPlanner.cs
+++ b/src/Pet.Jira.Application/Events/IDayWorklogPlanner.cs
@@ -1,0 +1,12 @@
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Planning;
+using System;
+using System.Collections.Generic;
+
+namespace Pet.Jira.Application.Events
+{
+    public interface IDayWorklogPlanner
+    {
+        IReadOnlyList<ProposedWorklog> Plan(DateOnly day, IReadOnlyList<Event> dayEvents);
+    }
+}

--- a/src/Pet.Jira.Application/Events/IEventAggregator.cs
+++ b/src/Pet.Jira.Application/Events/IEventAggregator.cs
@@ -9,6 +9,6 @@ namespace Pet.Jira.Application.Events
     public interface IEventAggregator
     {
         Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> GetEventsAsync(
-            DateOnly from, DateOnly to, CancellationToken ct);
+            DateOnly from, DateOnly to, CancellationToken cancellationToken);
     }
 }

--- a/src/Pet.Jira.Application/Events/IEventAggregator.cs
+++ b/src/Pet.Jira.Application/Events/IEventAggregator.cs
@@ -1,0 +1,14 @@
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Events
+{
+    public interface IEventAggregator
+    {
+        Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> GetEventsAsync(
+            DateOnly from, DateOnly to, CancellationToken ct = default);
+    }
+}

--- a/src/Pet.Jira.Application/Events/IEventAggregator.cs
+++ b/src/Pet.Jira.Application/Events/IEventAggregator.cs
@@ -9,6 +9,6 @@ namespace Pet.Jira.Application.Events
     public interface IEventAggregator
     {
         Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> GetEventsAsync(
-            DateOnly from, DateOnly to, CancellationToken ct = default);
+            DateOnly from, DateOnly to, CancellationToken ct);
     }
 }

--- a/src/Pet.Jira.Application/Events/IEventDataSource.cs
+++ b/src/Pet.Jira.Application/Events/IEventDataSource.cs
@@ -11,6 +11,6 @@ namespace Pet.Jira.Application.Events
         Task<IReadOnlyList<Event>> GetEventsAsync(
             DateOnly from,
             DateOnly to,
-            CancellationToken ct);
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Pet.Jira.Application/Events/IEventDataSource.cs
+++ b/src/Pet.Jira.Application/Events/IEventDataSource.cs
@@ -1,0 +1,16 @@
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Events
+{
+    public interface IEventDataSource
+    {
+        Task<IReadOnlyList<Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct);
+    }
+}

--- a/src/Pet.Jira.Application/Events/Queries/GetEvents.cs
+++ b/src/Pet.Jira.Application/Events/Queries/GetEvents.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Events.Queries
+{
+    public class GetEvents
+    {
+        public class Query : IRequest<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>>
+        {
+            public DateOnly From { get; set; }
+            public DateOnly To { get; set; }
+        }
+
+        public class QueryHandler
+            : IRequestHandler<Query, IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>>
+        {
+            private readonly IEventAggregator _aggregator;
+
+            public QueryHandler(IEventAggregator aggregator)
+            {
+                _aggregator = aggregator;
+            }
+
+            public Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> Handle(
+                Query request, CancellationToken cancellationToken)
+            {
+                return _aggregator.GetEventsAsync(request.From, request.To, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Pet.Jira.Application/Extensions/IUserExtensionRepository.cs
+++ b/src/Pet.Jira.Application/Extensions/IUserExtensionRepository.cs
@@ -7,8 +7,8 @@ namespace Pet.Jira.Application.Extensions
 {
     public interface IUserExtensionRepository
     {
-        Task<UserExtension?> GetAsync(string username, ExtensionType type, CancellationToken ct = default);
-        Task<IReadOnlyList<UserExtension>> GetAllAsync(string username, CancellationToken ct = default);
-        Task UpsertAsync(UserExtension extension, CancellationToken ct = default);
+        Task<UserExtension?> GetAsync(string username, ExtensionType type, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<UserExtension>> GetAllAsync(string username, CancellationToken cancellationToken = default);
+        Task UpsertAsync(UserExtension extension, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Commands/UpsertYandexCalendarExtension.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Commands/UpsertYandexCalendarExtension.cs
@@ -29,7 +29,7 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Commands
                 _protector = protector;
             }
 
-            public async Task Handle(Command request, CancellationToken ct)
+            public async Task Handle(Command request, CancellationToken cancellationToken)
             {
                 var stored = new StoredSettings(
                     request.Settings.Login,
@@ -39,7 +39,7 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Commands
                         .Select(m => new StoredMapping(m.Phrase, m.IssueKey))
                         .ToList());
 
-                var existing = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, ct);
+                var existing = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, cancellationToken);
 
                 var entity = existing ?? new UserExtension
                 {
@@ -52,7 +52,7 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Commands
                 entity.Settings = JsonSerializer.Serialize(stored);
                 entity.UpdatedAt = DateTime.UtcNow;
 
-                await _repository.UpsertAsync(entity, ct);
+                await _repository.UpsertAsync(entity, cancellationToken);
             }
 
             private record StoredMapping(string Phrase, string IssueKey);

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Dto/YandexCalendarEventDto.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Dto/YandexCalendarEventDto.cs
@@ -6,5 +6,8 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Dto
         string Summary,
         DateTime Start,
         DateTime End,
-        string? JiraIssueKeyHint);
+        string? JiraIssueKeyHint,
+        string? Uid,
+        string? Description,
+        Uri? Url);
 }

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/IYandexCalendarService.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/IYandexCalendarService.cs
@@ -14,6 +14,6 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar
             YandexCalendarCredentials credentials,
             DateOnly date,
             TimeZoneInfo userTimeZone,
-            CancellationToken ct = default);
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/IYandexCalendarSettingsProvider.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/IYandexCalendarSettingsProvider.cs
@@ -6,6 +6,6 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar
 {
     public interface IYandexCalendarSettingsProvider
     {
-        Task<YandexCalendarSettingsDto?> GetSettingsAsync(string username, CancellationToken ct = default);
+        Task<YandexCalendarSettingsDto?> GetSettingsAsync(string username, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/GetYandexCalendarEvents.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/GetYandexCalendarEvents.cs
@@ -35,24 +35,24 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Queries
                 _userProfileStorage = userProfileStorage;
             }
 
-            public async Task<IReadOnlyList<YandexCalendarEventDto>> Handle(Query request, CancellationToken ct)
+            public async Task<IReadOnlyList<YandexCalendarEventDto>> Handle(Query request, CancellationToken cancellationToken)
             {
-                var entity = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, ct);
+                var entity = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, cancellationToken);
                 if (entity is null || !entity.IsEnabled)
                     return Array.Empty<YandexCalendarEventDto>();
 
-                var settings = await _settings.GetSettingsAsync(request.Username, ct);
+                var settings = await _settings.GetSettingsAsync(request.Username, cancellationToken);
                 if (settings is null)
                     return Array.Empty<YandexCalendarEventDto>();
 
-                var userProfile = await _userProfileStorage.GetValueAsync(request.Username, ct);
+                var userProfile = await _userProfileStorage.GetValueAsync(request.Username, cancellationToken);
                 var userTimeZone = userProfile?.TimeZoneInfo ?? TimeZoneInfo.Local;
 
                 var utcEvents = await _calendar.GetEventsAsync(
                     new YandexCalendarCredentials(settings.Login, settings.AppPassword),
                     request.Date,
                     userTimeZone,
-                    ct);
+                    cancellationToken);
 
                 return utcEvents
                     .Where(e => !settings.ExcludedPhrases.Any(p =>

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/GetYandexCalendarSettings.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/GetYandexCalendarSettings.cs
@@ -21,13 +21,13 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Queries
                 _settingsProvider = settingsProvider;
             }
 
-            public async Task<YandexCalendarExtensionDto> Handle(Query request, CancellationToken ct)
+            public async Task<YandexCalendarExtensionDto> Handle(Query request, CancellationToken cancellationToken)
             {
-                var entity = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, ct);
+                var entity = await _repository.GetAsync(request.Username, ExtensionType.YandexCalendar, cancellationToken);
                 if (entity is null)
                     return new YandexCalendarExtensionDto(false, null);
 
-                var settings = await _settingsProvider.GetSettingsAsync(request.Username, ct);
+                var settings = await _settingsProvider.GetSettingsAsync(request.Username, cancellationToken);
                 return new YandexCalendarExtensionDto(entity.IsEnabled, settings);
             }
         }

--- a/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/TestYandexCalendarConnection.cs
+++ b/src/Pet.Jira.Application/Extensions/YandexCalendar/Queries/TestYandexCalendarConnection.cs
@@ -15,13 +15,13 @@ namespace Pet.Jira.Application.Extensions.YandexCalendar.Queries
 
             public Handler(IYandexCalendarService calendar) => _calendar = calendar;
 
-            public async Task<int> Handle(Query request, CancellationToken ct)
+            public async Task<int> Handle(Query request, CancellationToken cancellationToken)
             {
                 var events = await _calendar.GetEventsAsync(
                     new YandexCalendarCredentials(request.Login, request.AppPassword),
                     DateOnly.FromDateTime(DateTime.Today),
                     TimeZoneInfo.Local,
-                    ct);
+                    cancellationToken);
                 return events.Count;
             }
         }

--- a/src/Pet.Jira.Domain/Models/Events/Event.cs
+++ b/src/Pet.Jira.Domain/Models/Events/Event.cs
@@ -1,0 +1,15 @@
+using Pet.Jira.Domain.Models.Issues;
+using System;
+
+namespace Pet.Jira.Domain.Models.Events
+{
+    public record Event(
+        DateTime Start,
+        DateTime End,
+        string Title,
+        string? Description,
+        Uri? Link,
+        Issue? Issue,
+        EventSource Source
+    );
+}

--- a/src/Pet.Jira.Domain/Models/Events/Event.cs
+++ b/src/Pet.Jira.Domain/Models/Events/Event.cs
@@ -1,4 +1,3 @@
-using Pet.Jira.Domain.Models.Issues;
 using System;
 
 namespace Pet.Jira.Domain.Models.Events
@@ -10,7 +9,7 @@ namespace Pet.Jira.Domain.Models.Events
         string? Key,
         string? Description,
         Uri? Link,
-        Issue? Issue,
+        string? IssueKey,
         EventSource Source
     );
 }

--- a/src/Pet.Jira.Domain/Models/Events/Event.cs
+++ b/src/Pet.Jira.Domain/Models/Events/Event.cs
@@ -7,6 +7,7 @@ namespace Pet.Jira.Domain.Models.Events
         DateTime Start,
         DateTime End,
         string Title,
+        string? Key,
         string? Description,
         Uri? Link,
         Issue? Issue,

--- a/src/Pet.Jira.Domain/Models/Events/EventSource.cs
+++ b/src/Pet.Jira.Domain/Models/Events/EventSource.cs
@@ -1,0 +1,9 @@
+namespace Pet.Jira.Domain.Models.Events
+{
+    public enum EventSource
+    {
+        Calendar,
+        Task,
+        Comment
+    }
+}

--- a/src/Pet.Jira.Domain/Models/Planning/ProposedWorklog.cs
+++ b/src/Pet.Jira.Domain/Models/Planning/ProposedWorklog.cs
@@ -1,0 +1,14 @@
+using Pet.Jira.Domain.Models.Events;
+using System;
+
+namespace Pet.Jira.Domain.Models.Planning
+{
+    /// <summary>
+    /// A proposed loggable time slot for an <see cref="Event"/>. The seed of the
+    /// future worklog row on the Event pipeline.
+    /// </summary>
+    public record ProposedWorklog(Event Event, DateTime Start, DateTime End)
+    {
+        public TimeSpan Duration => End - Start;
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
+++ b/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
@@ -16,6 +16,7 @@ namespace Pet.Jira.Infrastructure.Events
         {
             var tasks = dayEvents
                 .Where(e => e.Source == EventSource.Task)
+                .OrderBy(e => e.Start)
                 .ToList();
 
             var result = new List<ProposedWorklog>();

--- a/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
+++ b/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
@@ -14,6 +14,10 @@ namespace Pet.Jira.Infrastructure.Events
 
         public IReadOnlyList<ProposedWorklog> Plan(DateOnly day, IReadOnlyList<Event> dayEvents)
         {
+            var calendar = dayEvents
+                .Where(e => e.Source == EventSource.Calendar)
+                .ToList();
+
             var tasks = dayEvents
                 .Where(e => e.Source == EventSource.Task)
                 .OrderBy(e => e.Start)
@@ -21,7 +25,14 @@ namespace Pet.Jira.Infrastructure.Events
 
             var result = new List<ProposedWorklog>();
 
-            var budget = Target;
+            // Calendar events keep their exact real time and act as hard blocks.
+            foreach (var calendarEvent in calendar)
+                result.Add(new ProposedWorklog(calendarEvent, calendarEvent.Start, calendarEvent.End));
+
+            var budget = Target - Sum(calendar);
+            if (budget < TimeSpan.Zero)
+                budget = TimeSpan.Zero;
+
             var totalTaskDuration = Sum(tasks);
 
             if (budget > TimeSpan.Zero && totalTaskDuration > TimeSpan.Zero)

--- a/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
+++ b/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
@@ -3,14 +3,48 @@ using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Domain.Models.Planning;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Pet.Jira.Infrastructure.Events
 {
     public class DayWorklogPlanner : IDayWorklogPlanner
     {
+        private static readonly TimeSpan Target = TimeSpan.FromHours(8);
+        private static readonly TimeOnly WindowStart = new(10, 0);
+
         public IReadOnlyList<ProposedWorklog> Plan(DateOnly day, IReadOnlyList<Event> dayEvents)
         {
-            return new List<ProposedWorklog>();
+            var tasks = dayEvents
+                .Where(e => e.Source == EventSource.Task)
+                .ToList();
+
+            var result = new List<ProposedWorklog>();
+
+            var budget = Target;
+            var totalTaskDuration = Sum(tasks);
+
+            if (budget > TimeSpan.Zero && totalTaskDuration > TimeSpan.Zero)
+            {
+                var cursor = day.ToDateTime(WindowStart);
+                var remaining = budget;
+                for (var i = 0; i < tasks.Count; i++)
+                {
+                    var duration = i == tasks.Count - 1
+                        ? remaining
+                        : budget * ((double)(tasks[i].End - tasks[i].Start).Ticks / totalTaskDuration.Ticks);
+                    remaining -= duration;
+
+                    var start = cursor;
+                    var end = cursor + duration;
+                    result.Add(new ProposedWorklog(tasks[i], start, end));
+                    cursor = end;
+                }
+            }
+
+            return result;
         }
+
+        private static TimeSpan Sum(IEnumerable<Event> events) =>
+            events.Aggregate(TimeSpan.Zero, (acc, e) => acc + (e.End - e.Start));
     }
 }

--- a/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
+++ b/src/Pet.Jira.Infrastructure/Events/DayWorklogPlanner.cs
@@ -1,0 +1,16 @@
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Planning;
+using System;
+using System.Collections.Generic;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class DayWorklogPlanner : IDayWorklogPlanner
+    {
+        public IReadOnlyList<ProposedWorklog> Plan(DateOnly day, IReadOnlyList<Event> dayEvents)
+        {
+            return new List<ProposedWorklog>();
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
+++ b/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
@@ -1,0 +1,47 @@
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class EventAggregator : IEventAggregator
+    {
+        private readonly IEnumerable<IEventDataSource> _sources;
+
+        public EventAggregator(IEnumerable<IEventDataSource> sources)
+        {
+            _sources = sources;
+        }
+
+        public async Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> GetEventsAsync(
+            DateOnly from, DateOnly to, CancellationToken ct)
+        {
+            var tasks = _sources.Select(s => s.GetEventsAsync(from, to, ct));
+            var results = await Task.WhenAll(tasks);
+            var allEvents = results.SelectMany(r => r);
+
+            var dict = new Dictionary<DateOnly, List<Event>>();
+            for (var day = from; day <= to; day = day.AddDays(1))
+                dict[day] = new List<Event>();
+
+            foreach (var e in allEvents)
+            {
+                var startDay = DateOnly.FromDateTime(e.Start);
+                var endDay = DateOnly.FromDateTime(e.End);
+                var loopStart = startDay < from ? from : startDay;
+                var loopEnd = endDay > to ? to : endDay;
+
+                for (var day = loopStart; day <= loopEnd; day = day.AddDays(1))
+                    dict[day].Add(e);
+            }
+
+            return dict.ToDictionary(
+                kvp => kvp.Key,
+                kvp => (IReadOnlyList<Event>)kvp.Value.OrderBy(e => e.Start).ToList());
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
+++ b/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
@@ -31,7 +31,9 @@ namespace Pet.Jira.Infrastructure.Events
             foreach (var e in allEvents)
             {
                 var startDay = DateOnly.FromDateTime(e.Start);
-                var endDay = DateOnly.FromDateTime(e.End);
+                var endDay = e.End.TimeOfDay == TimeSpan.Zero
+                    ? DateOnly.FromDateTime(e.End).AddDays(-1)
+                    : DateOnly.FromDateTime(e.End);
                 var loopStart = startDay < from ? from : startDay;
                 var loopEnd = endDay > to ? to : endDay;
 

--- a/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
+++ b/src/Pet.Jira.Infrastructure/Events/EventAggregator.cs
@@ -18,9 +18,9 @@ namespace Pet.Jira.Infrastructure.Events
         }
 
         public async Task<IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>>> GetEventsAsync(
-            DateOnly from, DateOnly to, CancellationToken ct)
+            DateOnly from, DateOnly to, CancellationToken cancellationToken)
         {
-            var tasks = _sources.Select(s => s.GetEventsAsync(from, to, ct));
+            var tasks = _sources.Select(s => s.GetEventsAsync(from, to, cancellationToken));
             var results = await Task.WhenAll(tasks);
             var allEvents = results.SelectMany(r => r);
 

--- a/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
@@ -31,7 +31,7 @@ namespace Pet.Jira.Infrastructure.Events
         public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
             DateOnly from,
             DateOnly to,
-            CancellationToken ct)
+            CancellationToken cancellationToken)
         {
             var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
             var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
@@ -48,13 +48,13 @@ namespace Pet.Jira.Infrastructure.Events
                 MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
             };
 
-            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
 
             var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
                 changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
 
             var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
-                issues, changeLogFilter, ChangeLogItemFilter, ct);
+                issues, changeLogFilter, ChangeLogItemFilter, cancellationToken);
 
             var events = new List<Domain.Models.Events.Event>();
             foreach (var issue in issues)

--- a/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
@@ -75,6 +75,7 @@ namespace Pet.Jira.Infrastructure.Events
                             Start: start,
                             End: end,
                             Title: issue.Name,
+                            Key: null,
                             Description: null,
                             Link: issue.Link != null ? new Uri(issue.Link) : null,
                             Issue: issue.Adapt(),

--- a/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
@@ -78,7 +78,7 @@ namespace Pet.Jira.Infrastructure.Events
                             Key: null,
                             Description: null,
                             Link: issue.Link != null ? new Uri(issue.Link) : null,
-                            Issue: issue.Adapt(),
+                            IssueKey: issue.Key,
                             Source: EventSource.Task));
                     }
                 }

--- a/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraChangeLogEventDataSource.cs
@@ -1,0 +1,89 @@
+using Atlassian.Jira;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public abstract class JiraChangeLogEventDataSource : IEventDataSource
+    {
+        private readonly IJiraService _jiraService;
+        private readonly IJiraQueryFactory _queryFactory;
+
+        protected JiraChangeLogEventDataSource(
+            IJiraService jiraService,
+            IJiraQueryFactory queryFactory)
+        {
+            _jiraService = jiraService;
+            _queryFactory = queryFactory;
+        }
+
+        protected abstract string AssigneeField { get; }
+
+        protected abstract Func<IssueChangeLogItem, bool> ChangeLogItemFilter { get; }
+
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct)
+        {
+            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
+            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+
+            var issueQuery = _queryFactory.Create()
+                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
+                .Where(AssigneeField, JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
+                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
+                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
+                .ToString();
+
+            var issueSearchOptions = new IssueSearchOptions(issueQuery)
+            {
+                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
+            };
+
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+
+            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
+                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
+
+            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
+                issues, changeLogFilter, ChangeLogItemFilter, ct);
+
+            var events = new List<Domain.Models.Events.Event>();
+            foreach (var issue in issues)
+            {
+                var issueItems = changeLogItems
+                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
+                    .OrderBy(item => item.ChangeLog.CreatedDate)
+                    .ToList();
+
+                for (int i = 0; i < issueItems.Count - 1; i++)
+                {
+                    var start = issueItems[i].ChangeLog.CreatedDate;
+                    var end = issueItems[i + 1].ChangeLog.CreatedDate;
+
+                    if (end >= fromDateTime && start <= toDateTime)
+                    {
+                        events.Add(new Domain.Models.Events.Event(
+                            Start: start,
+                            End: end,
+                            Title: issue.Name,
+                            Description: null,
+                            Link: issue.Link != null ? new Uri(issue.Link) : null,
+                            Issue: issue.Adapt(),
+                            Source: EventSource.Task));
+                    }
+                }
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
@@ -35,7 +35,7 @@ namespace Pet.Jira.Infrastructure.Events
         public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
             DateOnly from,
             DateOnly to,
-            CancellationToken ct)
+            CancellationToken cancellationToken)
         {
             var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
             var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
@@ -51,17 +51,17 @@ namespace Pet.Jira.Infrastructure.Events
                 MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
             };
 
-            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
 
             var user = await _identityService.GetCurrentUserAsync();
-            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, cancellationToken);
 
             var commentFilter = new Func<Comment, bool>(comment =>
                 comment.Author == userProfile!.Username
                 && comment.CreatedDate.Value >= fromDateTime
                 && comment.CreatedDate.Value <= toDateTime);
 
-            var comments = await _jiraService.GetIssueCommentsAsync(issues, commentFilter, ct);
+            var comments = await _jiraService.GetIssueCommentsAsync(issues, commentFilter, cancellationToken);
 
             var events = new List<Domain.Models.Events.Event>();
             foreach (var comment in comments)

--- a/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
@@ -1,0 +1,82 @@
+using Atlassian.Jira;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class JiraCommentEventDataSource : IEventDataSource
+    {
+        private readonly IJiraService _jiraService;
+        private readonly IJiraQueryFactory _queryFactory;
+        private readonly IIdentityService _identityService;
+        private readonly IStorage<string, UserProfile> _userProfileStorage;
+
+        public JiraCommentEventDataSource(
+            IJiraService jiraService,
+            IJiraQueryFactory queryFactory,
+            IIdentityService identityService,
+            IStorage<string, UserProfile> userProfileStorage)
+        {
+            _jiraService = jiraService;
+            _queryFactory = queryFactory;
+            _identityService = identityService;
+            _userProfileStorage = userProfileStorage;
+        }
+
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct)
+        {
+            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
+            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+
+            var issueQuery = _queryFactory.Create()
+                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
+                .Where("watcher", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
+                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
+                .ToString();
+
+            var issueSearchOptions = new IssueSearchOptions(issueQuery)
+            {
+                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
+            };
+
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+
+            var user = await _identityService.GetCurrentUserAsync();
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
+
+            var commentFilter = new Func<Comment, bool>(comment =>
+                comment.Author == userProfile!.Username
+                && comment.CreatedDate.Value >= fromDateTime
+                && comment.CreatedDate.Value <= toDateTime);
+
+            var comments = await _jiraService.GetIssueCommentsAsync(issues, commentFilter, ct);
+
+            var events = new List<Domain.Models.Events.Event>();
+            foreach (var comment in comments)
+            {
+                events.Add(new Domain.Models.Events.Event(
+                    Start: comment.CreatedDate,
+                    End: comment.CreatedDate,
+                    Title: comment.Issue.Name,
+                    Description: comment.Body,
+                    Link: comment.Issue.Link != null ? new Uri(comment.Issue.Link) : null,
+                    Issue: comment.Issue.Adapt(),
+                    Source: EventSource.Comment));
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
@@ -73,7 +73,7 @@ namespace Pet.Jira.Infrastructure.Events
                     Key: null,
                     Description: comment.Body,
                     Link: comment.Issue.Link != null ? new Uri(comment.Issue.Link) : null,
-                    Issue: comment.Issue.Adapt(),
+                    IssueKey: comment.Issue.Key,
                     Source: EventSource.Comment));
             }
 

--- a/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraCommentEventDataSource.cs
@@ -70,6 +70,7 @@ namespace Pet.Jira.Infrastructure.Events
                     Start: comment.CreatedDate,
                     End: comment.CreatedDate,
                     Title: comment.Issue.Name,
+                    Key: null,
                     Description: comment.Body,
                     Link: comment.Issue.Link != null ? new Uri(comment.Issue.Link) : null,
                     Issue: comment.Issue.Adapt(),

--- a/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
@@ -1,0 +1,97 @@
+using Atlassian.Jira;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class JiraTaskEventDataSource : IEventDataSource
+    {
+        private readonly IJiraService _jiraService;
+        private readonly IJiraQueryFactory _queryFactory;
+        private readonly IIdentityService _identityService;
+        private readonly IStorage<string, UserProfile> _userProfileStorage;
+
+        public JiraTaskEventDataSource(
+            IJiraService jiraService,
+            IJiraQueryFactory queryFactory,
+            IIdentityService identityService,
+            IStorage<string, UserProfile> userProfileStorage)
+        {
+            _jiraService = jiraService;
+            _queryFactory = queryFactory;
+            _identityService = identityService;
+            _userProfileStorage = userProfileStorage;
+        }
+
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct)
+        {
+            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
+            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+
+            var issueQuery = _queryFactory.Create()
+                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
+                .Where("assignee", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
+                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
+                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
+                .ToString();
+
+            var issueSearchOptions = new IssueSearchOptions(issueQuery)
+            {
+                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
+            };
+
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+
+            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
+                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
+
+            var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
+                changeLogItem.FieldName == JiraConstants.Status.FieldName);
+
+            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
+                issues, changeLogFilter, changeLogItemFilter, ct);
+
+            var events = new List<Domain.Models.Events.Event>();
+            foreach (var issue in issues)
+            {
+                var issueItems = changeLogItems
+                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
+                    .OrderBy(item => item.ChangeLog.CreatedDate)
+                    .ToList();
+
+                for (int i = 0; i < issueItems.Count - 1; i++)
+                {
+                    var start = issueItems[i].ChangeLog.CreatedDate;
+                    var end = issueItems[i + 1].ChangeLog.CreatedDate;
+
+                    if (end >= fromDateTime && start <= toDateTime)
+                    {
+                        events.Add(new Domain.Models.Events.Event(
+                            Start: start,
+                            End: end,
+                            Title: issue.Name,
+                            Description: null,
+                            Link: issue.Link != null ? new Uri(issue.Link) : null,
+                            Issue: issue.Adapt(),
+                            Source: EventSource.Task));
+                    }
+                }
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
@@ -1,20 +1,111 @@
 using Atlassian.Jira;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Application.Time;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Query;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Pet.Jira.Infrastructure.Events
 {
-    public class JiraTaskEventDataSource : JiraChangeLogEventDataSource
+    /// <summary>
+    /// Surfaces the intervals during which the current user's issues were
+    /// "In Progress", mirroring the assignee worklog logic of
+    /// <see cref="Jira.JiraWorklogDataSource.GetRawIssueWorklogsAsync"/>.
+    /// </summary>
+    public class JiraTaskEventDataSource : IEventDataSource
     {
+        private const string AssigneeField = "assignee";
+
+        private readonly IJiraService _jiraService;
+        private readonly IJiraQueryFactory _queryFactory;
+        private readonly IIdentityService _identityService;
+        private readonly IStorage<string, UserProfile> _userProfileStorage;
+        private readonly ITimeProvider _timeProvider;
+
         public JiraTaskEventDataSource(
             IJiraService jiraService,
-            IJiraQueryFactory queryFactory)
-            : base(jiraService, queryFactory) { }
+            IJiraQueryFactory queryFactory,
+            IIdentityService identityService,
+            IStorage<string, UserProfile> userProfileStorage,
+            ITimeProvider timeProvider)
+        {
+            _jiraService = jiraService;
+            _queryFactory = queryFactory;
+            _identityService = identityService;
+            _userProfileStorage = userProfileStorage;
+            _timeProvider = timeProvider;
+        }
 
-        protected override string AssigneeField => "assignee";
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken cancellationToken)
+        {
+            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
+            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+            var inProgressStatusId = JiraConstants.Status.Default.Id;
 
-        protected override Func<IssueChangeLogItem, bool> ChangeLogItemFilter =>
-            item => item.FieldName == JiraConstants.Status.FieldName;
+            var issueQuery = _queryFactory.Create()
+                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
+                .Where(AssigneeField, JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
+                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
+                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
+                .ToString();
+
+            var issueSearchOptions = new IssueSearchOptions(issueQuery)
+            {
+                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
+            };
+
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
+
+            var user = await _identityService.GetCurrentUserAsync();
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, cancellationToken);
+
+            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
+                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
+
+            var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(item =>
+                item.FieldName == JiraConstants.Status.FieldName
+                && (item.ToId == inProgressStatusId || item.FromId == inProgressStatusId));
+
+            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
+                issues, changeLogFilter, changeLogItemFilter, cancellationToken);
+
+            var events = new List<Domain.Models.Events.Event>();
+            foreach (var issue in issues)
+            {
+                var intervals = changeLogItems
+                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
+                    .OrderBy(item => item.ChangeLog.CreatedDate)
+                    .ToList()
+                    .ToStatusIntervals(inProgressStatusId, _timeProvider, userProfile.TimeZoneInfo)
+                    .Where(interval => interval.OverlapsWith(fromDateTime, toDateTime)
+                        && interval.Author == userProfile.Username);
+
+                foreach (var interval in intervals)
+                {
+                    events.Add(new Domain.Models.Events.Event(
+                        Start: interval.Start,
+                        End: interval.End,
+                        Title: issue.Name,
+                        Key: null,
+                        Description: null,
+                        Link: issue.Link != null ? new Uri(issue.Link) : null,
+                        IssueKey: issue.Key,
+                        Source: EventSource.Task));
+                }
+            }
+
+            return events;
+        }
     }
 }

--- a/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
@@ -1,88 +1,20 @@
 using Atlassian.Jira;
-using Pet.Jira.Application.Events;
-using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Query;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Pet.Jira.Infrastructure.Events
 {
-    public class JiraTaskEventDataSource : IEventDataSource
+    public class JiraTaskEventDataSource : JiraChangeLogEventDataSource
     {
-        private readonly IJiraService _jiraService;
-        private readonly IJiraQueryFactory _queryFactory;
-
         public JiraTaskEventDataSource(
             IJiraService jiraService,
             IJiraQueryFactory queryFactory)
-        {
-            _jiraService = jiraService;
-            _queryFactory = queryFactory;
-        }
+            : base(jiraService, queryFactory) { }
 
-        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
-            DateOnly from,
-            DateOnly to,
-            CancellationToken ct)
-        {
-            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
-            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+        protected override string AssigneeField => "assignee";
 
-            var issueQuery = _queryFactory.Create()
-                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
-                .Where("assignee", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
-                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
-                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
-                .ToString();
-
-            var issueSearchOptions = new IssueSearchOptions(issueQuery)
-            {
-                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
-            };
-
-            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
-
-            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
-                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
-
-            var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
-                changeLogItem.FieldName == JiraConstants.Status.FieldName);
-
-            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
-                issues, changeLogFilter, changeLogItemFilter, ct);
-
-            var events = new List<Domain.Models.Events.Event>();
-            foreach (var issue in issues)
-            {
-                var issueItems = changeLogItems
-                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
-                    .OrderBy(item => item.ChangeLog.CreatedDate)
-                    .ToList();
-
-                for (int i = 0; i < issueItems.Count - 1; i++)
-                {
-                    var start = issueItems[i].ChangeLog.CreatedDate;
-                    var end = issueItems[i + 1].ChangeLog.CreatedDate;
-
-                    if (end >= fromDateTime && start <= toDateTime)
-                    {
-                        events.Add(new Domain.Models.Events.Event(
-                            Start: start,
-                            End: end,
-                            Title: issue.Name,
-                            Description: null,
-                            Link: issue.Link != null ? new Uri(issue.Link) : null,
-                            Issue: issue.Adapt(),
-                            Source: EventSource.Task));
-                    }
-                }
-            }
-
-            return events;
-        }
+        protected override Func<IssueChangeLogItem, bool> ChangeLogItemFilter =>
+            item => item.FieldName == JiraConstants.Status.FieldName;
     }
 }

--- a/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTaskEventDataSource.cs
@@ -1,9 +1,6 @@
 using Atlassian.Jira;
-using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Events;
-using Pet.Jira.Application.Storage;
 using Pet.Jira.Domain.Models.Events;
-using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Query;
 using System;
@@ -18,19 +15,13 @@ namespace Pet.Jira.Infrastructure.Events
     {
         private readonly IJiraService _jiraService;
         private readonly IJiraQueryFactory _queryFactory;
-        private readonly IIdentityService _identityService;
-        private readonly IStorage<string, UserProfile> _userProfileStorage;
 
         public JiraTaskEventDataSource(
             IJiraService jiraService,
-            IJiraQueryFactory queryFactory,
-            IIdentityService identityService,
-            IStorage<string, UserProfile> userProfileStorage)
+            IJiraQueryFactory queryFactory)
         {
             _jiraService = jiraService;
             _queryFactory = queryFactory;
-            _identityService = identityService;
-            _userProfileStorage = userProfileStorage;
         }
 
         public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(

--- a/src/Pet.Jira.Infrastructure/Events/JiraTesterEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTesterEventDataSource.cs
@@ -1,0 +1,92 @@
+using Atlassian.Jira;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class JiraTesterEventDataSource : IEventDataSource
+    {
+        private const string InTestingStatusId = "10116";
+
+        private readonly IJiraService _jiraService;
+        private readonly IJiraQueryFactory _queryFactory;
+
+        public JiraTesterEventDataSource(
+            IJiraService jiraService,
+            IJiraQueryFactory queryFactory)
+        {
+            _jiraService = jiraService;
+            _queryFactory = queryFactory;
+        }
+
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct)
+        {
+            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
+            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+
+            var issueQuery = _queryFactory.Create()
+                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
+                .Where("Tester", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
+                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
+                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
+                .ToString();
+
+            var issueSearchOptions = new IssueSearchOptions(issueQuery)
+            {
+                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
+            };
+
+            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
+
+            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
+                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
+
+            var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
+                changeLogItem.FieldName == JiraConstants.Status.FieldName
+                && (changeLogItem.ToId == InTestingStatusId
+                    || changeLogItem.FromId == InTestingStatusId));
+
+            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
+                issues, changeLogFilter, changeLogItemFilter, ct);
+
+            var events = new List<Domain.Models.Events.Event>();
+            foreach (var issue in issues)
+            {
+                var issueItems = changeLogItems
+                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
+                    .OrderBy(item => item.ChangeLog.CreatedDate)
+                    .ToList();
+
+                for (int i = 0; i < issueItems.Count - 1; i++)
+                {
+                    var start = issueItems[i].ChangeLog.CreatedDate;
+                    var end = issueItems[i + 1].ChangeLog.CreatedDate;
+
+                    if (end >= fromDateTime && start <= toDateTime)
+                    {
+                        events.Add(new Domain.Models.Events.Event(
+                            Start: start,
+                            End: end,
+                            Title: issue.Name,
+                            Description: null,
+                            Link: issue.Link != null ? new Uri(issue.Link) : null,
+                            Issue: issue.Adapt(),
+                            Source: EventSource.Task));
+                    }
+                }
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/JiraTesterEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/JiraTesterEventDataSource.cs
@@ -1,92 +1,23 @@
 using Atlassian.Jira;
-using Pet.Jira.Application.Events;
-using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Query;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Pet.Jira.Infrastructure.Events
 {
-    public class JiraTesterEventDataSource : IEventDataSource
+    public class JiraTesterEventDataSource : JiraChangeLogEventDataSource
     {
         private const string InTestingStatusId = "10116";
-
-        private readonly IJiraService _jiraService;
-        private readonly IJiraQueryFactory _queryFactory;
 
         public JiraTesterEventDataSource(
             IJiraService jiraService,
             IJiraQueryFactory queryFactory)
-        {
-            _jiraService = jiraService;
-            _queryFactory = queryFactory;
-        }
+            : base(jiraService, queryFactory) { }
 
-        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
-            DateOnly from,
-            DateOnly to,
-            CancellationToken ct)
-        {
-            var fromDateTime = from.ToDateTime(TimeOnly.MinValue);
-            var toDateTime = to.ToDateTime(TimeOnly.MaxValue);
+        protected override string AssigneeField => "Tester";
 
-            var issueQuery = _queryFactory.Create()
-                .Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, fromDateTime)
-                .Where("Tester", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
-                .Where("type", JiraQueryComparisonType.NotEqual, "Story")
-                .OrderBy("updatedDate", JiraQueryOrderType.Desc)
-                .ToString();
-
-            var issueSearchOptions = new IssueSearchOptions(issueQuery)
-            {
-                MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
-            };
-
-            var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, ct);
-
-            var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
-                changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
-
-            var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
-                changeLogItem.FieldName == JiraConstants.Status.FieldName
-                && (changeLogItem.ToId == InTestingStatusId
-                    || changeLogItem.FromId == InTestingStatusId));
-
-            var changeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(
-                issues, changeLogFilter, changeLogItemFilter, ct);
-
-            var events = new List<Domain.Models.Events.Event>();
-            foreach (var issue in issues)
-            {
-                var issueItems = changeLogItems
-                    .Where(item => item.ChangeLog.Issue.Key == issue.Key)
-                    .OrderBy(item => item.ChangeLog.CreatedDate)
-                    .ToList();
-
-                for (int i = 0; i < issueItems.Count - 1; i++)
-                {
-                    var start = issueItems[i].ChangeLog.CreatedDate;
-                    var end = issueItems[i + 1].ChangeLog.CreatedDate;
-
-                    if (end >= fromDateTime && start <= toDateTime)
-                    {
-                        events.Add(new Domain.Models.Events.Event(
-                            Start: start,
-                            End: end,
-                            Title: issue.Name,
-                            Description: null,
-                            Link: issue.Link != null ? new Uri(issue.Link) : null,
-                            Issue: issue.Adapt(),
-                            Source: EventSource.Task));
-                    }
-                }
-            }
-
-            return events;
-        }
+        protected override Func<IssueChangeLogItem, bool> ChangeLogItemFilter =>
+            item => item.FieldName == JiraConstants.Status.FieldName
+                && (item.ToId == InTestingStatusId || item.FromId == InTestingStatusId);
     }
 }

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -1,0 +1,84 @@
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Extensions.YandexCalendar;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Jira;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Infrastructure.Events
+{
+    public class YandexCalendarEventDataSource : IEventDataSource
+    {
+        private readonly IYandexCalendarService _calendarService;
+        private readonly IYandexCalendarSettingsProvider _settingsProvider;
+        private readonly IIdentityService _identityService;
+        private readonly IStorage<string, UserProfile> _userProfileStorage;
+        private readonly IJiraService _jiraService;
+
+        public YandexCalendarEventDataSource(
+            IYandexCalendarService calendarService,
+            IYandexCalendarSettingsProvider settingsProvider,
+            IIdentityService identityService,
+            IStorage<string, UserProfile> userProfileStorage,
+            IJiraService jiraService)
+        {
+            _calendarService = calendarService;
+            _settingsProvider = settingsProvider;
+            _identityService = identityService;
+            _userProfileStorage = userProfileStorage;
+            _jiraService = jiraService;
+        }
+
+        public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
+            DateOnly from,
+            DateOnly to,
+            CancellationToken ct)
+        {
+            var user = await _identityService.GetCurrentUserAsync();
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
+            var settings = await _settingsProvider.GetSettingsAsync(user.Key, ct);
+
+            if (settings is null)
+                return Array.Empty<Domain.Models.Events.Event>();
+
+            var credentials = new YandexCalendarCredentials(settings.Login, settings.AppPassword);
+            var events = new List<Domain.Models.Events.Event>();
+
+            for (var date = from; date <= to; date = date.AddDays(1))
+            {
+                var calendarEvents = await _calendarService.GetEventsAsync(
+                    credentials, date, userProfile!.TimeZoneInfo, ct);
+
+                foreach (var calEvent in calendarEvents)
+                {
+                    Domain.Models.Issues.Issue? issue = null;
+                    if (calEvent.JiraIssueKeyHint is not null)
+                    {
+                        try
+                        {
+                            var issueDto = await _jiraService.GetIssueAsync(calEvent.JiraIssueKeyHint, ct);
+                            issue = issueDto.Adapt();
+                        }
+                        catch { }
+                    }
+
+                    events.Add(new Domain.Models.Events.Event(
+                        Start: calEvent.Start,
+                        End: calEvent.End,
+                        Title: calEvent.Summary,
+                        Description: null,
+                        Link: null,
+                        Issue: issue,
+                        Source: EventSource.Calendar));
+                }
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -56,8 +56,9 @@ namespace Pet.Jira.Infrastructure.Events
                         Start: calEvent.Start,
                         End: calEvent.End,
                         Title: calEvent.Summary,
-                        Description: null,
-                        Link: null,
+                        Key: calEvent.Uid,
+                        Description: calEvent.Description,
+                        Link: calEvent.Url,
                         Issue: null,
                         Source: EventSource.Calendar));
                 }

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -39,19 +39,19 @@ namespace Pet.Jira.Infrastructure.Events
         public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
             DateOnly from,
             DateOnly to,
-            CancellationToken ct)
+            CancellationToken cancellationToken)
         {
             var user = await _identityService.GetCurrentUserAsync();
 
-            var extension = await _extensionRepository.GetAsync(user.Key, ExtensionType.YandexCalendar, ct);
+            var extension = await _extensionRepository.GetAsync(user.Key, ExtensionType.YandexCalendar, cancellationToken);
             if (extension is null || !extension.IsEnabled)
                 return Array.Empty<Domain.Models.Events.Event>();
 
-            var settings = await _settingsProvider.GetSettingsAsync(user.Key, ct);
+            var settings = await _settingsProvider.GetSettingsAsync(user.Key, cancellationToken);
             if (settings is null)
                 return Array.Empty<Domain.Models.Events.Event>();
 
-            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, cancellationToken);
             var userTimeZone = userProfile?.TimeZoneInfo ?? TimeZoneInfo.Local;
 
             var credentials = new YandexCalendarCredentials(settings.Login, settings.AppPassword);
@@ -60,7 +60,7 @@ namespace Pet.Jira.Infrastructure.Events
             for (var date = from; date <= to; date = date.AddDays(1))
             {
                 var calendarEvents = await _calendarService.GetEventsAsync(
-                    credentials, date, userTimeZone, ct);
+                    credentials, date, userTimeZone, cancellationToken);
 
                 foreach (var calEvent in calendarEvents)
                 {

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -62,19 +62,19 @@ namespace Pet.Jira.Infrastructure.Events
                 var calendarEvents = await _calendarService.GetEventsAsync(
                     credentials, date, userTimeZone, cancellationToken);
 
-                foreach (var calEvent in calendarEvents)
+                foreach (var calendarEvent in calendarEvents)
                 {
                     if (settings.ExcludedPhrases.Any(p =>
-                            calEvent.Summary.Contains(p, StringComparison.OrdinalIgnoreCase)))
+                            calendarEvent.Summary.Contains(p, StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     events.Add(new Domain.Models.Events.Event(
-                        Start: TimeZoneInfo.ConvertTimeFromUtc(calEvent.Start, userTimeZone),
-                        End: TimeZoneInfo.ConvertTimeFromUtc(calEvent.End, userTimeZone),
-                        Title: calEvent.Summary,
-                        Key: calEvent.Uid,
-                        Description: calEvent.Description,
-                        Link: calEvent.Url,
+                        Start: TimeZoneInfo.ConvertTimeFromUtc(calendarEvent.Start, userTimeZone),
+                        End: TimeZoneInfo.ConvertTimeFromUtc(calendarEvent.End, userTimeZone),
+                        Title: calendarEvent.Summary,
+                        Key: calendarEvent.Uid,
+                        Description: calendarEvent.Description,
+                        Link: calendarEvent.Url,
                         Issue: null,
                         Source: EventSource.Calendar));
                 }

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -1,11 +1,14 @@
 using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Extensions;
 using Pet.Jira.Application.Extensions.YandexCalendar;
 using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Entities.Extensions;
 using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Domain.Models.Users;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,17 +18,20 @@ namespace Pet.Jira.Infrastructure.Events
     {
         private readonly IYandexCalendarService _calendarService;
         private readonly IYandexCalendarSettingsProvider _settingsProvider;
+        private readonly IUserExtensionRepository _extensionRepository;
         private readonly IIdentityService _identityService;
         private readonly IStorage<string, UserProfile> _userProfileStorage;
 
         public YandexCalendarEventDataSource(
             IYandexCalendarService calendarService,
             IYandexCalendarSettingsProvider settingsProvider,
+            IUserExtensionRepository extensionRepository,
             IIdentityService identityService,
             IStorage<string, UserProfile> userProfileStorage)
         {
             _calendarService = calendarService;
             _settingsProvider = settingsProvider;
+            _extensionRepository = extensionRepository;
             _identityService = identityService;
             _userProfileStorage = userProfileStorage;
         }
@@ -36,11 +42,17 @@ namespace Pet.Jira.Infrastructure.Events
             CancellationToken ct)
         {
             var user = await _identityService.GetCurrentUserAsync();
-            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
-            var settings = await _settingsProvider.GetSettingsAsync(user.Key, ct);
 
+            var extension = await _extensionRepository.GetAsync(user.Key, ExtensionType.YandexCalendar, ct);
+            if (extension is null || !extension.IsEnabled)
+                return Array.Empty<Domain.Models.Events.Event>();
+
+            var settings = await _settingsProvider.GetSettingsAsync(user.Key, ct);
             if (settings is null)
                 return Array.Empty<Domain.Models.Events.Event>();
+
+            var userProfile = await _userProfileStorage.GetValueAsync(user.Key, ct);
+            var userTimeZone = userProfile?.TimeZoneInfo ?? TimeZoneInfo.Local;
 
             var credentials = new YandexCalendarCredentials(settings.Login, settings.AppPassword);
             var events = new List<Domain.Models.Events.Event>();
@@ -48,13 +60,17 @@ namespace Pet.Jira.Infrastructure.Events
             for (var date = from; date <= to; date = date.AddDays(1))
             {
                 var calendarEvents = await _calendarService.GetEventsAsync(
-                    credentials, date, userProfile!.TimeZoneInfo, ct);
+                    credentials, date, userTimeZone, ct);
 
                 foreach (var calEvent in calendarEvents)
                 {
+                    if (settings.ExcludedPhrases.Any(p =>
+                            calEvent.Summary.Contains(p, StringComparison.OrdinalIgnoreCase)))
+                        continue;
+
                     events.Add(new Domain.Models.Events.Event(
-                        Start: calEvent.Start,
-                        End: calEvent.End,
+                        Start: TimeZoneInfo.ConvertTimeFromUtc(calEvent.Start, userTimeZone),
+                        End: TimeZoneInfo.ConvertTimeFromUtc(calEvent.End, userTimeZone),
                         Title: calEvent.Summary,
                         Key: calEvent.Uid,
                         Description: calEvent.Description,

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -64,8 +64,8 @@ namespace Pet.Jira.Infrastructure.Events
 
                 foreach (var calendarEvent in calendarEvents)
                 {
-                    if (settings.ExcludedPhrases.Any(p =>
-                            calendarEvent.Summary.Contains(p, StringComparison.OrdinalIgnoreCase)))
+                    if (settings.ExcludedPhrases.Any(excludedPhrase =>
+                            calendarEvent.Summary.Contains(excludedPhrase, StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     events.Add(new Domain.Models.Events.Event(
@@ -75,7 +75,7 @@ namespace Pet.Jira.Infrastructure.Events
                         Key: calendarEvent.Uid,
                         Description: calendarEvent.Description,
                         Link: calendarEvent.Url,
-                        Issue: null,
+                        IssueKey: calendarEvent.JiraIssueKeyHint,
                         Source: EventSource.Calendar));
                 }
             }

--- a/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Events/YandexCalendarEventDataSource.cs
@@ -4,7 +4,6 @@ using Pet.Jira.Application.Extensions.YandexCalendar;
 using Pet.Jira.Application.Storage;
 using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Domain.Models.Users;
-using Pet.Jira.Infrastructure.Jira;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -18,20 +17,17 @@ namespace Pet.Jira.Infrastructure.Events
         private readonly IYandexCalendarSettingsProvider _settingsProvider;
         private readonly IIdentityService _identityService;
         private readonly IStorage<string, UserProfile> _userProfileStorage;
-        private readonly IJiraService _jiraService;
 
         public YandexCalendarEventDataSource(
             IYandexCalendarService calendarService,
             IYandexCalendarSettingsProvider settingsProvider,
             IIdentityService identityService,
-            IStorage<string, UserProfile> userProfileStorage,
-            IJiraService jiraService)
+            IStorage<string, UserProfile> userProfileStorage)
         {
             _calendarService = calendarService;
             _settingsProvider = settingsProvider;
             _identityService = identityService;
             _userProfileStorage = userProfileStorage;
-            _jiraService = jiraService;
         }
 
         public async Task<IReadOnlyList<Domain.Models.Events.Event>> GetEventsAsync(
@@ -56,24 +52,13 @@ namespace Pet.Jira.Infrastructure.Events
 
                 foreach (var calEvent in calendarEvents)
                 {
-                    Domain.Models.Issues.Issue? issue = null;
-                    if (calEvent.JiraIssueKeyHint is not null)
-                    {
-                        try
-                        {
-                            var issueDto = await _jiraService.GetIssueAsync(calEvent.JiraIssueKeyHint, ct);
-                            issue = issueDto.Adapt();
-                        }
-                        catch { }
-                    }
-
                     events.Add(new Domain.Models.Events.Event(
                         Start: calEvent.Start,
                         End: calEvent.End,
                         Title: calEvent.Summary,
                         Description: null,
                         Link: null,
-                        Issue: issue,
+                        Issue: null,
                         Source: EventSource.Calendar));
                 }
             }

--- a/src/Pet.Jira.Infrastructure/Extensions/UserExtensionRepository.cs
+++ b/src/Pet.Jira.Infrastructure/Extensions/UserExtensionRepository.cs
@@ -15,26 +15,26 @@ namespace Pet.Jira.Infrastructure.Extensions
 
         public UserExtensionRepository(ApplicationDbContext db) => _db = db;
 
-        public Task<UserExtension?> GetAsync(string username, ExtensionType type, CancellationToken ct = default)
+        public Task<UserExtension?> GetAsync(string username, ExtensionType type, CancellationToken cancellationToken = default)
             => _db.Set<UserExtension>()
-                  .FirstOrDefaultAsync(e => e.Username == username && e.Type == type, ct);
+                  .FirstOrDefaultAsync(e => e.Username == username && e.Type == type, cancellationToken);
 
-        public async Task<IReadOnlyList<UserExtension>> GetAllAsync(string username, CancellationToken ct = default)
+        public async Task<IReadOnlyList<UserExtension>> GetAllAsync(string username, CancellationToken cancellationToken = default)
             => await _db.Set<UserExtension>()
                         .Where(e => e.Username == username)
-                        .ToListAsync(ct);
+                        .ToListAsync(cancellationToken);
 
-        public async Task UpsertAsync(UserExtension extension, CancellationToken ct = default)
+        public async Task UpsertAsync(UserExtension extension, CancellationToken cancellationToken = default)
         {
             var exists = await _db.Set<UserExtension>()
-                .AnyAsync(e => e.Username == extension.Username && e.Type == extension.Type, ct);
+                .AnyAsync(e => e.Username == extension.Username && e.Type == extension.Type, cancellationToken);
 
             if (exists)
                 _db.Set<UserExtension>().Update(extension);
             else
                 _db.Set<UserExtension>().Add(extension);
 
-            await _db.SaveChangesAsync(ct);
+            await _db.SaveChangesAsync(cancellationToken);
         }
     }
 }

--- a/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalDavService.cs
+++ b/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalDavService.cs
@@ -96,7 +96,14 @@ namespace Pet.Jira.Infrastructure.Extensions.YandexCalendar
                     var match = JiraKeyRegex.Match(summary + " " + description);
                     var hint = match.Success ? match.Value : null;
 
-                    result.Add(new YandexCalendarEventDto(summary, start, end, hint));
+                    result.Add(new YandexCalendarEventDto(
+                        Summary: summary,
+                        Start: start,
+                        End: end,
+                        JiraIssueKeyHint: hint,
+                        Uid: vevent.Uid,
+                        Description: string.IsNullOrEmpty(description) ? null : description,
+                        Url: vevent.Url));
                 }
             }
 

--- a/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalDavService.cs
+++ b/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalDavService.cs
@@ -29,7 +29,7 @@ namespace Pet.Jira.Infrastructure.Extensions.YandexCalendar
             YandexCalendarCredentials credentials,
             DateOnly date,
             TimeZoneInfo userTimeZone,
-            CancellationToken ct = default)
+            CancellationToken cancellationToken = default)
         {
             var url = string.Format(CalDavBaseUrl, credentials.Login);
             var body = BuildReportBody(date, userTimeZone);
@@ -44,10 +44,10 @@ namespace Pet.Jira.Infrastructure.Extensions.YandexCalendar
                     Encoding.UTF8.GetBytes($"{credentials.Login}:{credentials.AppPassword}")));
             request.Headers.Add("Depth", "1");
 
-            var response = await _http.SendAsync(request, ct);
+            var response = await _http.SendAsync(request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var xml = await response.Content.ReadAsStringAsync(ct);
+            var xml = await response.Content.ReadAsStringAsync(cancellationToken);
             return ParseCalDavResponse(xml, date);
         }
 

--- a/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalendarSettingsProvider.cs
+++ b/src/Pet.Jira.Infrastructure/Extensions/YandexCalendar/YandexCalendarSettingsProvider.cs
@@ -23,9 +23,9 @@ namespace Pet.Jira.Infrastructure.Extensions.YandexCalendar
             _protector = protector;
         }
 
-        public async Task<YandexCalendarSettingsDto?> GetSettingsAsync(string username, CancellationToken ct = default)
+        public async Task<YandexCalendarSettingsDto?> GetSettingsAsync(string username, CancellationToken cancellationToken = default)
         {
-            var entity = await _repository.GetAsync(username, ExtensionType.YandexCalendar, ct);
+            var entity = await _repository.GetAsync(username, ExtensionType.YandexCalendar, cancellationToken);
             if (entity is null || string.IsNullOrEmpty(entity.Settings))
                 return null;
 

--- a/src/Pet.Jira.Infrastructure/Jira/Dto/IssueCommentDto.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/Dto/IssueCommentDto.cs
@@ -7,6 +7,7 @@ namespace Pet.Jira.Infrastructure.Jira.Dto
         public DateTime CreatedDate { get; set; }
         public IssueDto Issue { get; set; }
         public string Author { get; set; }
+        public string? Body { get; set; }
 
         public static IssueCommentDto Create(
             Atlassian.Jira.Comment comment,
@@ -16,7 +17,8 @@ namespace Pet.Jira.Infrastructure.Jira.Dto
             {
                 CreatedDate = comment.CreatedDate.Value,
                 Issue = issue,
-                Author = comment.Author
+                Author = comment.Author,
+                Body = comment.Body
             };
         }
     }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
@@ -3,6 +3,7 @@ using Pet.Jira.Domain.Models.Worklogs;
 using Pet.Jira.Infrastructure.Jira.Dto;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Pet.Jira.Infrastructure.Jira
@@ -24,6 +25,28 @@ namespace Pet.Jira.Infrastructure.Jira
 			WorklogSource worklogSource)
             where T : IWorklog, new()
         {
+            return issueChangeLogItems
+                .ToStatusIntervals(issueStatusId, timeProvider, timeZoneInfo)
+                .Select(interval => new T
+                {
+                    StartDate = interval.Start,
+                    CompleteDate = interval.End,
+                    Issue = interval.Issue.Adapt(),
+                    Author = interval.Author,
+                    Source = worklogSource
+                });
+        }
+
+        /// <summary>
+        /// Pairs ordered status-change changelog items into the time intervals an
+        /// issue spent in <paramref name="issueStatusId"/>. Worklog-agnostic core
+        /// shared by the worklog and event pipelines.
+        /// </summary>
+        public static IEnumerable<StatusInterval> ToStatusIntervals(this IList<IssueChangeLogItemDto> issueChangeLogItems,
+            string issueStatusId,
+            ITimeProvider timeProvider,
+            TimeZoneInfo timeZoneInfo)
+        {
             var i = 0;
             while (i < issueChangeLogItems.Count)
             {
@@ -31,38 +54,29 @@ namespace Pet.Jira.Infrastructure.Jira
                 // 1. Первый элемент сразу выходит из прогресса. Значит это завершающий
                 if (item.FromId == issueStatusId)
                 {
-                    yield return new T()
-                    {
-                        CompleteDate = timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
-                        StartDate = DateTime.MinValue,
-                        Issue = item.ChangeLog.Issue.Adapt(),
-                        Author = item.Author,
-                        Source = worklogSource
-					};
+                    yield return new StatusInterval(
+                        Start: DateTime.MinValue,
+                        End: timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
+                        Author: item.Author,
+                        Issue: item.ChangeLog.Issue);
                 }
                 // 2. Это последний элемент и он не завершается
                 else if (i == (issueChangeLogItems.Count - 1))
                 {
-                    yield return new T()
-                    {
-                        CompleteDate = DateTime.MaxValue,
-                        StartDate = timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
-                        Issue = item.ChangeLog.Issue.Adapt(),
-                        Author = item.Author,
-                        Source = worklogSource
-					};
+                    yield return new StatusInterval(
+                        Start: timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
+                        End: DateTime.MaxValue,
+                        Author: item.Author,
+                        Issue: item.ChangeLog.Issue);
                 }
                 // 3. Обычный случай когда после FromInProgress следует ToInProgress
                 else
                 {
-                    yield return new T()
-                    {
-                        CompleteDate = timeProvider.ConvertToUserTimezone(issueChangeLogItems[i + 1].ChangeLog.CreatedDate, timeZoneInfo),
-                        StartDate = timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
-                        Issue = item.ChangeLog.Issue.Adapt(),
-                        Author = item.Author,
-                        Source = worklogSource
-					};
+                    yield return new StatusInterval(
+                        Start: timeProvider.ConvertToUserTimezone(item.ChangeLog.CreatedDate, timeZoneInfo),
+                        End: timeProvider.ConvertToUserTimezone(issueChangeLogItems[i + 1].ChangeLog.CreatedDate, timeZoneInfo),
+                        Author: item.Author,
+                        Issue: item.ChangeLog.Issue);
                 }
 
                 i += 2;

--- a/src/Pet.Jira.Infrastructure/Jira/StatusInterval.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/StatusInterval.cs
@@ -1,0 +1,23 @@
+using Pet.Jira.Infrastructure.Jira.Dto;
+using System;
+
+namespace Pet.Jira.Infrastructure.Jira
+{
+    /// <summary>
+    /// A worklog-agnostic time interval during which an issue stayed in a given
+    /// status, derived from ordered status-change changelog items. Both the
+    /// worklog and event pipelines map from this primitive.
+    /// </summary>
+    public readonly record struct StatusInterval(
+        DateTime Start,
+        DateTime End,
+        string Author,
+        IssueDto Issue)
+    {
+        /// <summary>
+        /// True when the interval overlaps the [from, to] range.
+        /// </summary>
+        public bool OverlapsWith(DateTime from, DateTime to)
+            => Start < to && End > from;
+    }
+}

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ namespace Pet.Jira.Infrastructure
 			services.AddTransient<IEventDataSource, JiraTaskEventDataSource>();
 			services.AddTransient<IEventDataSource, JiraTesterEventDataSource>();
 			services.AddTransient<IEventAggregator, EventAggregator>();
+			services.AddTransient<IDayWorklogPlanner, DayWorklogPlanner>();
 
 			return services;
         }

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -79,6 +79,7 @@ namespace Pet.Jira.Infrastructure
 			services.AddTransient<IEventDataSource, JiraCommentEventDataSource>();
 			services.AddTransient<IEventDataSource, JiraTaskEventDataSource>();
 			services.AddTransient<IEventDataSource, JiraTesterEventDataSource>();
+			services.AddTransient<IEventAggregator, EventAggregator>();
 
 			return services;
         }

--- a/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ using Pet.Jira.Application.Security;
 using Pet.Jira.Infrastructure.Extensions;
 using Pet.Jira.Infrastructure.Extensions.YandexCalendar;
 using Pet.Jira.Infrastructure.Security;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Infrastructure.Events;
 
 namespace Pet.Jira.Infrastructure
 {
@@ -72,6 +74,11 @@ namespace Pet.Jira.Infrastructure
 			services.AddHttpClient<IYandexCalendarService, YandexCalDavService>();
 			services.AddTransient<IUserExtensionRepository, UserExtensionRepository>();
 			services.AddTransient<IYandexCalendarSettingsProvider, YandexCalendarSettingsProvider>();
+
+			services.AddTransient<IEventDataSource, YandexCalendarEventDataSource>();
+			services.AddTransient<IEventDataSource, JiraCommentEventDataSource>();
+			services.AddTransient<IEventDataSource, JiraTaskEventDataSource>();
+			services.AddTransient<IEventDataSource, JiraTesterEventDataSource>();
 
 			return services;
         }

--- a/src/Pet.Jira.Web/Pages/Events.razor
+++ b/src/Pet.Jira.Web/Pages/Events.razor
@@ -27,10 +27,10 @@ else
                             @FormatTime(e)
                         </MudText>
                         <MudText>@e.Title</MudText>
-                        @if (e.Issue != null)
+                        @if (e.IssueKey != null)
                         {
                             <MudText Typo="Typo.body2" Color="Color.Primary">
-                                @e.Issue.Key
+                                @e.IssueKey
                             </MudText>
                         }
                     </MudStack>

--- a/src/Pet.Jira.Web/Pages/Events.razor
+++ b/src/Pet.Jira.Web/Pages/Events.razor
@@ -1,0 +1,41 @@
+@page "/events"
+
+<MudText Typo="Typo.h5" Class="mb-4">Events</MudText>
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else
+{
+    @foreach (var day in _events.Keys.OrderBy(d => d))
+    {
+        var dayEvents = _events[day];
+        @if (dayEvents.Any())
+        {
+            <MudText Typo="Typo.subtitle1" Class="mt-4 mb-2">
+                @day.ToString("dddd, d MMMM")
+            </MudText>
+            @foreach (var e in dayEvents)
+            {
+                <MudPaper Class="pa-3 mb-2" Elevation="1">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudChip T="string" Size="Size.Small" Color="@GetSourceColor(e.Source)">
+                            @e.Source
+                        </MudChip>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @FormatTime(e)
+                        </MudText>
+                        <MudText>@e.Title</MudText>
+                        @if (e.Issue != null)
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Primary">
+                                @e.Issue.Key
+                            </MudText>
+                        }
+                    </MudStack>
+                </MudPaper>
+            }
+        }
+    }
+}

--- a/src/Pet.Jira.Web/Pages/Events.razor
+++ b/src/Pet.Jira.Web/Pages/Events.razor
@@ -33,6 +33,16 @@ else
                                 @e.IssueKey
                             </MudText>
                         }
+                        @{
+                            var proposed = GetProposed(e);
+                        }
+                        @if (proposed != null)
+                        {
+                            <MudSpacer />
+                            <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
+                                @FormatProposed(proposed)
+                            </MudChip>
+                        }
                     </MudStack>
                 </MudPaper>
             }

--- a/src/Pet.Jira.Web/Pages/Events.razor
+++ b/src/Pet.Jira.Web/Pages/Events.razor
@@ -33,10 +33,7 @@ else
                                 @e.IssueKey
                             </MudText>
                         }
-                        @{
-                            var proposed = GetProposed(e);
-                        }
-                        @if (proposed != null)
+                        @if (GetProposed(e) is { } proposed)
                         {
                             <MudSpacer />
                             <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">

--- a/src/Pet.Jira.Web/Pages/Events.razor.cs
+++ b/src/Pet.Jira.Web/Pages/Events.razor.cs
@@ -50,7 +50,7 @@ namespace Pet.Jira.Web.Pages
             _proposed.TryGetValue(e, out var proposed) ? proposed : null;
 
         private static string FormatProposed(ProposedWorklog p) =>
-            $"{p.Start:HH:mm} – {p.End:HH:mm} ({p.Duration.TotalHours:0.##}h)";
+            FormattableString.Invariant($"{p.Start:HH:mm} – {p.End:HH:mm} ({p.Duration.TotalHours:0.##}h)");
 
         private static string FormatTime(Event e) =>
             e.Start == e.End

--- a/src/Pet.Jira.Web/Pages/Events.razor.cs
+++ b/src/Pet.Jira.Web/Pages/Events.razor.cs
@@ -37,8 +37,10 @@ namespace Pet.Jira.Web.Pages
 
         private static string FormatTime(Event e) =>
             e.Start == e.End
-                ? e.Start.ToString("HH:mm")
-                : $"{e.Start:HH:mm} – {e.End:HH:mm}";
+                ? e.Start.ToString("dd.MM HH:mm")
+                : e.Start.Date == e.End.Date
+                    ? $"{e.Start:dd.MM HH:mm} – {e.End:HH:mm}"
+                    : $"{e.Start:dd.MM HH:mm} – {e.End:dd.MM HH:mm}";
 
         private static Color GetSourceColor(EventSource source) => source switch
         {

--- a/src/Pet.Jira.Web/Pages/Events.razor.cs
+++ b/src/Pet.Jira.Web/Pages/Events.razor.cs
@@ -1,8 +1,10 @@
 using MediatR;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
+using Pet.Jira.Application.Events;
 using Pet.Jira.Application.Events.Queries;
 using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Planning;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,9 +15,12 @@ namespace Pet.Jira.Web.Pages
     public partial class Events : ComponentBase
     {
         [Inject] private IMediator Mediator { get; set; } = default!;
+        [Inject] private IDayWorklogPlanner Planner { get; set; } = default!;
 
         private IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>> _events =
             new Dictionary<DateOnly, IReadOnlyList<Event>>();
+        private Dictionary<Event, ProposedWorklog> _proposed =
+            new(ReferenceEqualityComparer.Instance);
         private bool _loading = true;
 
         protected override async Task OnInitializedAsync()
@@ -28,12 +33,24 @@ namespace Pet.Jira.Web.Pages
             try
             {
                 _events = await Mediator.Send(new GetEvents.Query { From = monday, To = sunday });
+                // Reference equality: Event is a record (value equality), so value-equal
+                // duplicates would otherwise collide as dictionary keys.
+                var comparer = (IEqualityComparer<Event>)ReferenceEqualityComparer.Instance;
+                _proposed = _events
+                    .SelectMany(kvp => Planner.Plan(kvp.Key, kvp.Value))
+                    .ToDictionary(p => p.Event, p => p, comparer);
             }
             finally
             {
                 _loading = false;
             }
         }
+
+        private ProposedWorklog? GetProposed(Event e) =>
+            _proposed.TryGetValue(e, out var proposed) ? proposed : null;
+
+        private static string FormatProposed(ProposedWorklog p) =>
+            $"{p.Start:HH:mm} – {p.End:HH:mm} ({p.Duration.TotalHours:0.##}h)";
 
         private static string FormatTime(Event e) =>
             e.Start == e.End

--- a/src/Pet.Jira.Web/Pages/Events.razor.cs
+++ b/src/Pet.Jira.Web/Pages/Events.razor.cs
@@ -1,0 +1,51 @@
+using MediatR;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pet.Jira.Application.Events.Queries;
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Web.Pages
+{
+    public partial class Events : ComponentBase
+    {
+        [Inject] private IMediator Mediator { get; set; } = default!;
+
+        private IReadOnlyDictionary<DateOnly, IReadOnlyList<Event>> _events =
+            new Dictionary<DateOnly, IReadOnlyList<Event>>();
+        private bool _loading = true;
+
+        protected override async Task OnInitializedAsync()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var daysFromMonday = today.DayOfWeek == DayOfWeek.Sunday ? 6 : (int)today.DayOfWeek - 1;
+            var monday = today.AddDays(-daysFromMonday);
+            var sunday = monday.AddDays(6);
+
+            try
+            {
+                _events = await Mediator.Send(new GetEvents.Query { From = monday, To = sunday });
+            }
+            finally
+            {
+                _loading = false;
+            }
+        }
+
+        private static string FormatTime(Event e) =>
+            e.Start == e.End
+                ? e.Start.ToString("HH:mm")
+                : $"{e.Start:HH:mm} – {e.End:HH:mm}";
+
+        private static Color GetSourceColor(EventSource source) => source switch
+        {
+            EventSource.Calendar => Color.Info,
+            EventSource.Task     => Color.Primary,
+            EventSource.Comment  => Color.Default,
+            _                    => Color.Default
+        };
+    }
+}

--- a/src/Pet.Jira.Web/Shared/NavMenu.razor
+++ b/src/Pet.Jira.Web/Shared/NavMenu.razor
@@ -1,6 +1,7 @@
 ﻿<MudPaper Width="100%" Class="py-3" Height="100%" Elevation="1">
     <MudNavMenu Bordered="true">
         <MudNavLink Href="/worklogs" Icon="@Icons.Material.Outlined.Timer">Worklogs</MudNavLink>
+        <MudNavLink Href="/events" Icon="@Icons.Material.Outlined.EventNote">Events</MudNavLink>
         <MudNavLink Href="/faq" Icon="@Icons.Material.Outlined.QuestionAnswer">FAQ</MudNavLink>
         <MudNavLink Href="/articles" Icon="@Icons.Material.Outlined.Newspaper">Project</MudNavLink>
         <MudNavLink Href="/extensions" Icon="@Icons.Material.Outlined.Extension">Extensions<span class="nav-badge--new">new</span></MudNavLink>

--- a/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/GetYandexCalendarEventsHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Extensions/YandexCalendar/GetYandexCalendarEventsHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
             var utcEnd   = new DateTime(2026, 6, 4, 11, 0, 0, DateTimeKind.Utc);
             var events = new List<YandexCalendarEventDto>
             {
-                new("Standup PROJ-42", utcStart, utcEnd, "PROJ-42")
+                new("Standup PROJ-42", utcStart, utcEnd, "PROJ-42", null, null, null)
             };
             _calMock.Setup(c => c.GetEventsAsync(
                         It.Is<YandexCalendarCredentials>(cr => cr.Login == "user@yandex.ru"),
@@ -83,9 +83,9 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
             var utcNow = new DateTime(2026, 6, 4, 10, 0, 0, DateTimeKind.Utc);
             var events = new List<YandexCalendarEventDto>
             {
-                new("Standup", utcNow, utcNow.AddHours(1), null),
-                new("Обед с командой", utcNow.AddHours(2), utcNow.AddHours(3), null),
-                new("Team Lunch", utcNow.AddHours(3), utcNow.AddHours(4), null),
+                new("Standup", utcNow, utcNow.AddHours(1), null, null, null, null),
+                new("Обед с командой", utcNow.AddHours(2), utcNow.AddHours(3), null, null, null, null),
+                new("Team Lunch", utcNow.AddHours(3), utcNow.AddHours(4), null, null, null, null),
             };
             _calMock.Setup(c => c.GetEventsAsync(
                         It.IsAny<YandexCalendarCredentials>(),
@@ -119,8 +119,8 @@ namespace Pet.Jira.UnitTests.Application.Extensions.YandexCalendar
             var utcNow = new DateTime(2026, 6, 4, 10, 0, 0, DateTimeKind.Utc);
             var events = new List<YandexCalendarEventDto>
             {
-                new("Core Daily Sync", utcNow, utcNow.AddHours(1), null),
-                new("Other Meeting",   utcNow.AddHours(2), utcNow.AddHours(3), null),
+                new("Core Daily Sync", utcNow, utcNow.AddHours(1), null, null, null, null),
+                new("Other Meeting",   utcNow.AddHours(2), utcNow.AddHours(3), null, null, null, null),
             };
             _calMock.Setup(c => c.GetEventsAsync(
                         It.IsAny<YandexCalendarCredentials>(),

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
@@ -56,5 +56,58 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Duration, Is.EqualTo(TimeSpan.FromHours(6)));  // 3h weight -> 6h
             Assert.That(result[1].Duration, Is.EqualTo(TimeSpan.FromHours(2)));  // 1h weight -> 2h
         }
+
+        [Test]
+        public void Plan_CalendarPlusTask_CalendarExact_TaskFillsRemainder()
+        {
+            var meeting = Calendar(new DateTime(2026, 6, 1, 11, 0, 0), new DateTime(2026, 6, 1, 13, 0, 0)); // 2h
+            var task = Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 9, 30, 0));         // 0.5h
+            var events = new List<Event> { meeting, task };
+
+            var result = _sut.Plan(_day, events);
+
+            var calendarSlot = result.Single(p => p.Event == meeting);
+            Assert.That(calendarSlot.Start, Is.EqualTo(meeting.Start));
+            Assert.That(calendarSlot.End, Is.EqualTo(meeting.End));
+
+            var taskSlot = result.Single(p => p.Event == task);
+            Assert.That(taskSlot.Duration, Is.EqualTo(TimeSpan.FromHours(6))); // 8h - 2h
+            Assert.That(taskSlot.Start, Is.EqualTo(new DateTime(2026, 6, 1, 10, 0, 0)));
+
+            Assert.That(result.Sum(p => p.Duration.Ticks), Is.EqualTo(TimeSpan.FromHours(8).Ticks));
+        }
+
+        [Test]
+        public void Plan_CalendarFillsEightHours_TasksGetNothing()
+        {
+            var meeting = Calendar(new DateTime(2026, 6, 1, 10, 0, 0), new DateTime(2026, 6, 1, 18, 0, 0)); // 8h
+            var task = Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 10, 0, 0));
+            var events = new List<Event> { meeting, task };
+
+            var result = _sut.Plan(_day, events);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result.Single().Event, Is.SameAs(meeting));
+        }
+
+        [Test]
+        public void Plan_CalendarExceedsEightHours_TasksGetNothing_NoNegative()
+        {
+            var meeting = Calendar(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 18, 0, 0)); // 9h
+            var task = Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 10, 0, 0));
+            var events = new List<Event> { meeting, task };
+
+            var result = _sut.Plan(_day, events);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result.Single().Event, Is.SameAs(meeting));
+        }
+
+        [Test]
+        public void Plan_NoEvents_ReturnsEmpty()
+        {
+            var result = _sut.Plan(_day, new List<Event>());
+            Assert.That(result, Is.Empty);
+        }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
@@ -41,5 +41,20 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Start, Is.EqualTo(new DateTime(2026, 6, 1, 10, 0, 0)));
             Assert.That(result[1].Start, Is.EqualTo(result[0].End));
         }
+
+        [Test]
+        public void Plan_TasksOutOfOrder_PackedInRealStartOrder()
+        {
+            var late = Task(new DateTime(2026, 6, 1, 16, 0, 0), new DateTime(2026, 6, 1, 17, 0, 0));  // 1h
+            var early = Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 12, 0, 0));   // 3h
+            var events = new List<Event> { late, early };
+
+            var result = _sut.Plan(_day, events);
+
+            Assert.That(result[0].Event, Is.SameAs(early));
+            Assert.That(result[1].Event, Is.SameAs(late));
+            Assert.That(result[0].Duration, Is.EqualTo(TimeSpan.FromHours(6)));  // 3h weight -> 6h
+            Assert.That(result[1].Duration, Is.EqualTo(TimeSpan.FromHours(2)));  // 1h weight -> 2h
+        }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Infrastructure.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class DayWorklogPlannerTests
+    {
+        private readonly DateOnly _day = new(2026, 6, 1);
+        private IDayWorklogPlanner _sut;
+
+        [SetUp]
+        public void Setup() => _sut = new DayWorklogPlanner();
+
+        private Event Task(DateTime start, DateTime end) =>
+            new(start, end, "task", null, null, null, "PROJ-1", EventSource.Task);
+
+        private Event Calendar(DateTime start, DateTime end) =>
+            new(start, end, "meeting", null, null, null, null, EventSource.Calendar);
+
+        [Test]
+        public void Plan_TwoEqualTasks_SplitEightHoursEqually_PackedFromTen()
+        {
+            var events = new List<Event>
+            {
+                Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 11, 0, 0)),  // 2h
+                Task(new DateTime(2026, 6, 1, 15, 0, 0), new DateTime(2026, 6, 1, 17, 0, 0)), // 2h
+            };
+
+            var result = _sut.Plan(_day, events);
+
+            Assert.That(result, Has.Count.EqualTo(2));
+            Assert.That(result.Sum(p => p.Duration.Ticks), Is.EqualTo(TimeSpan.FromHours(8).Ticks));
+            Assert.That(result[0].Duration, Is.EqualTo(TimeSpan.FromHours(4)));
+            Assert.That(result[1].Duration, Is.EqualTo(TimeSpan.FromHours(4)));
+            Assert.That(result[0].Start, Is.EqualTo(new DateTime(2026, 6, 1, 10, 0, 0)));
+            Assert.That(result[1].Start, Is.EqualTo(result[0].End));
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/DayWorklogPlannerTests.cs
@@ -109,5 +109,36 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var result = _sut.Plan(_day, new List<Event>());
             Assert.That(result, Is.Empty);
         }
+
+        [Test]
+        public void Plan_MultipleCalendarEvents_BudgetSubtractsTheirSum()
+        {
+            var morning = Calendar(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 10, 0, 0));   // 1h
+            var afternoon = Calendar(new DateTime(2026, 6, 1, 14, 0, 0), new DateTime(2026, 6, 1, 15, 30, 0)); // 1.5h
+            var task = Task(new DateTime(2026, 6, 1, 11, 0, 0), new DateTime(2026, 6, 1, 11, 30, 0));
+            var events = new List<Event> { morning, afternoon, task };
+
+            var result = _sut.Plan(_day, events);
+
+            var taskSlot = result.Single(p => p.Event == task);
+            Assert.That(taskSlot.Duration, Is.EqualTo(TimeSpan.FromHours(5.5))); // 8h - (1h + 1.5h)
+            Assert.That(result.Sum(p => p.Duration.Ticks), Is.EqualTo(TimeSpan.FromHours(8).Ticks));
+        }
+
+        [Test]
+        public void Plan_ThreeUnequalTasks_SumIsExactlyEightHours()
+        {
+            var t1 = Task(new DateTime(2026, 6, 1, 9, 0, 0), new DateTime(2026, 6, 1, 10, 0, 0));   // 1h
+            var t2 = Task(new DateTime(2026, 6, 1, 10, 0, 0), new DateTime(2026, 6, 1, 12, 0, 0));  // 2h
+            var t3 = Task(new DateTime(2026, 6, 1, 12, 0, 0), new DateTime(2026, 6, 1, 16, 0, 0));  // 4h
+            var events = new List<Event> { t1, t2, t3 };
+
+            var result = _sut.Plan(_day, events);
+
+            Assert.That(result, Has.Count.EqualTo(3));
+            // 1h/2h/4h weights of an 8h budget produce non-integer tick slices;
+            // the last-task-remainder logic must still make the sum exact.
+            Assert.That(result.Sum(p => p.Duration.Ticks), Is.EqualTo(TimeSpan.FromHours(8).Ticks));
+        }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
@@ -34,7 +34,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var multiDayEvent = new Event(
                 new DateTime(2026, 6, 1, 10, 0, 0),
                 new DateTime(2026, 6, 3, 15, 0, 0),
-                "Task A", null, null, null, EventSource.Task);
+                "Task A", null, null, null, null, EventSource.Task);
 
             _source1Mock
                 .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -58,11 +58,11 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var calendarEvent = new Event(
                 new DateTime(2026, 6, 1, 9, 0, 0),
                 new DateTime(2026, 6, 1, 10, 0, 0),
-                "Meeting", null, null, null, EventSource.Calendar);
+                "Meeting", null, null, null, null, EventSource.Calendar);
             var taskEvent = new Event(
                 new DateTime(2026, 6, 1, 11, 0, 0),
                 new DateTime(2026, 6, 1, 13, 0, 0),
-                "Task B", null, null, null, EventSource.Task);
+                "Task B", null, null, null, null, EventSource.Task);
 
             _source1Mock
                 .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -86,7 +86,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var outsideEvent = new Event(
                 new DateTime(2026, 6, 1, 10, 0, 0),
                 new DateTime(2026, 6, 1, 11, 0, 0),
-                "Old event", null, null, null, EventSource.Calendar);
+                "Old event", null, null, null, null, EventSource.Calendar);
 
             _source1Mock
                 .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -109,11 +109,11 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var laterEvent = new Event(
                 new DateTime(2026, 6, 1, 14, 0, 0),
                 new DateTime(2026, 6, 1, 15, 0, 0),
-                "Later", null, null, null, EventSource.Task);
+                "Later", null, null, null, null, EventSource.Task);
             var earlierEvent = new Event(
                 new DateTime(2026, 6, 1, 9, 0, 0),
                 new DateTime(2026, 6, 1, 10, 0, 0),
-                "Earlier", null, null, null, EventSource.Calendar);
+                "Earlier", null, null, null, null, EventSource.Calendar);
 
             _source1Mock
                 .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -136,7 +136,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             var midnightEndEvent = new Event(
                 new DateTime(2026, 6, 1, 10, 0, 0),
                 new DateTime(2026, 6, 2, 0, 0, 0),
-                "Status period", null, null, null, EventSource.Task);
+                "Status period", null, null, null, null, EventSource.Task);
 
             _source1Mock
                 .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
@@ -1,0 +1,130 @@
+using Moq;
+using NUnit.Framework;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Domain.Models.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class EventAggregatorTests
+    {
+        private Mock<IEventDataSource> _source1Mock;
+        private Mock<IEventDataSource> _source2Mock;
+        private Pet.Jira.Infrastructure.Events.EventAggregator _sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _source1Mock = new Mock<IEventDataSource>();
+            _source2Mock = new Mock<IEventDataSource>();
+            _sut = new Pet.Jira.Infrastructure.Events.EventAggregator(
+                new[] { _source1Mock.Object, _source2Mock.Object });
+        }
+
+        [Test]
+        public async Task GetEventsAsync_MultiDayEvent_AppearsOnEachDayItSpans()
+        {
+            var from = new DateOnly(2026, 6, 1);
+            var to = new DateOnly(2026, 6, 3);
+            var multiDayEvent = new Event(
+                new DateTime(2026, 6, 1, 10, 0, 0),
+                new DateTime(2026, 6, 3, 15, 0, 0),
+                "Task A", null, null, null, EventSource.Task);
+
+            _source1Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { multiDayEvent });
+            _source2Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await _sut.GetEventsAsync(from, to, CancellationToken.None);
+
+            Assert.That(result[new DateOnly(2026, 6, 1)], Contains.Item(multiDayEvent));
+            Assert.That(result[new DateOnly(2026, 6, 2)], Contains.Item(multiDayEvent));
+            Assert.That(result[new DateOnly(2026, 6, 3)], Contains.Item(multiDayEvent));
+        }
+
+        [Test]
+        public async Task GetEventsAsync_MultipleSourcesMerged()
+        {
+            var from = new DateOnly(2026, 6, 1);
+            var to = new DateOnly(2026, 6, 1);
+            var calendarEvent = new Event(
+                new DateTime(2026, 6, 1, 9, 0, 0),
+                new DateTime(2026, 6, 1, 10, 0, 0),
+                "Meeting", null, null, null, EventSource.Calendar);
+            var taskEvent = new Event(
+                new DateTime(2026, 6, 1, 11, 0, 0),
+                new DateTime(2026, 6, 1, 13, 0, 0),
+                "Task B", null, null, null, EventSource.Task);
+
+            _source1Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { calendarEvent });
+            _source2Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { taskEvent });
+
+            var result = await _sut.GetEventsAsync(from, to, CancellationToken.None);
+
+            Assert.That(result[from], Has.Count.EqualTo(2));
+            Assert.That(result[from], Contains.Item(calendarEvent));
+            Assert.That(result[from], Contains.Item(taskEvent));
+        }
+
+        [Test]
+        public async Task GetEventsAsync_EventOutsideRange_NotIncluded()
+        {
+            var from = new DateOnly(2026, 6, 2);
+            var to = new DateOnly(2026, 6, 3);
+            var outsideEvent = new Event(
+                new DateTime(2026, 6, 1, 10, 0, 0),
+                new DateTime(2026, 6, 1, 11, 0, 0),
+                "Old event", null, null, null, EventSource.Calendar);
+
+            _source1Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { outsideEvent });
+            _source2Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await _sut.GetEventsAsync(from, to, CancellationToken.None);
+
+            Assert.That(result[from], Is.Empty);
+            Assert.That(result[new DateOnly(2026, 6, 3)], Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_EventsWithinDay_SortedByStartTime()
+        {
+            var from = new DateOnly(2026, 6, 1);
+            var to = new DateOnly(2026, 6, 1);
+            var laterEvent = new Event(
+                new DateTime(2026, 6, 1, 14, 0, 0),
+                new DateTime(2026, 6, 1, 15, 0, 0),
+                "Later", null, null, null, EventSource.Task);
+            var earlierEvent = new Event(
+                new DateTime(2026, 6, 1, 9, 0, 0),
+                new DateTime(2026, 6, 1, 10, 0, 0),
+                "Earlier", null, null, null, EventSource.Calendar);
+
+            _source1Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { laterEvent, earlierEvent });
+            _source2Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await _sut.GetEventsAsync(from, to, CancellationToken.None);
+
+            Assert.That(result[from][0], Is.EqualTo(earlierEvent));
+            Assert.That(result[from][1], Is.EqualTo(laterEvent));
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/EventAggregatorTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NUnit.Framework;
 using Pet.Jira.Application.Events;
 using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Infrastructure.Events;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -14,14 +15,14 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
     {
         private Mock<IEventDataSource> _source1Mock;
         private Mock<IEventDataSource> _source2Mock;
-        private Pet.Jira.Infrastructure.Events.EventAggregator _sut;
+        private EventAggregator _sut;
 
         [SetUp]
         public void SetUp()
         {
             _source1Mock = new Mock<IEventDataSource>();
             _source2Mock = new Mock<IEventDataSource>();
-            _sut = new Pet.Jira.Infrastructure.Events.EventAggregator(
+            _sut = new EventAggregator(
                 new[] { _source1Mock.Object, _source2Mock.Object });
         }
 
@@ -125,6 +126,29 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
 
             Assert.That(result[from][0], Is.EqualTo(earlierEvent));
             Assert.That(result[from][1], Is.EqualTo(laterEvent));
+        }
+
+        [Test]
+        public async Task GetEventsAsync_EventEndingAtMidnight_BucketedOnStartDay()
+        {
+            var from = new DateOnly(2026, 6, 1);
+            var to = new DateOnly(2026, 6, 2);
+            var midnightEndEvent = new Event(
+                new DateTime(2026, 6, 1, 10, 0, 0),
+                new DateTime(2026, 6, 2, 0, 0, 0),
+                "Status period", null, null, null, EventSource.Task);
+
+            _source1Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event> { midnightEndEvent });
+            _source2Mock
+                .Setup(s => s.GetEventsAsync(from, to, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await _sut.GetEventsAsync(from, to, CancellationToken.None);
+
+            Assert.That(result[new DateOnly(2026, 6, 1)], Contains.Item(midnightEndEvent));
+            Assert.That(result[new DateOnly(2026, 6, 2)], Is.Empty);
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraCommentEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraCommentEventDataSourceTests.cs
@@ -109,7 +109,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Title, Is.EqualTo("PROJ-1. Some task"));
             Assert.That(result[0].Description, Is.EqualTo("Done."));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Comment));
-            Assert.That(result[0].Issue, Is.Not.Null);
+            Assert.That(result[0].IssueKey, Is.EqualTo("PROJ-1"));
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraCommentEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraCommentEventDataSourceTests.cs
@@ -1,0 +1,115 @@
+using Atlassian.Jira;
+using Moq;
+using NUnit.Framework;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Dto;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class JiraCommentEventDataSourceTests
+    {
+        private Mock<IJiraService> _jiraServiceMock;
+        private Mock<IJiraQueryFactory> _queryFactoryMock;
+        private Mock<IIdentityService> _identityServiceMock;
+        private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
+        private IEventDataSource _sut;
+        private CancellationToken _ct;
+
+        [SetUp]
+        public void Setup()
+        {
+            _jiraServiceMock = new Mock<IJiraService>();
+            _queryFactoryMock = new Mock<IJiraQueryFactory>();
+            _identityServiceMock = new Mock<IIdentityService>();
+            _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
+            _sut = new JiraCommentEventDataSource(
+                _jiraServiceMock.Object,
+                _queryFactoryMock.Object,
+                _identityServiceMock.Object,
+                _userProfileStorageMock.Object);
+            _ct = CancellationToken.None;
+
+            _identityServiceMock
+                .Setup(x => x.GetCurrentUserAsync())
+                .ReturnsAsync(new Pet.Jira.Domain.Models.Users.User { Username = "user1" });
+
+            _userProfileStorageMock
+                .Setup(x => x.GetValueAsync("user1", _ct))
+                .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
+
+            _queryFactoryMock.Setup(x => x.Create()).Returns(new JiraQuery());
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenNoComments_ReturnsEmptyList()
+        {
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto>());
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueCommentsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<Comment, bool>>(),
+                    _ct))
+                .ReturnsAsync(new List<IssueCommentDto>());
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenCommentsExist_ReturnsMappedEventsWithStartEqualsEnd()
+        {
+            var issue = new IssueDto { Key = "PROJ-1", Summary = "Some task", Link = "http://jira/PROJ-1" };
+            var commentTime = new DateTime(2026, 6, 1, 14, 0, 0);
+            var comment = new IssueCommentDto
+            {
+                CreatedDate = commentTime,
+                Issue = issue,
+                Author = "user1",
+                Body = "Done."
+            };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto> { issue });
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueCommentsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<Comment, bool>>(),
+                    _ct))
+                .ReturnsAsync(new List<IssueCommentDto> { comment });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Start, Is.EqualTo(commentTime));
+            Assert.That(result[0].End, Is.EqualTo(commentTime));
+            Assert.That(result[0].Title, Is.EqualTo("PROJ-1. Some task"));
+            Assert.That(result[0].Description, Is.EqualTo("Done."));
+            Assert.That(result[0].Source, Is.EqualTo(EventSource.Comment));
+            Assert.That(result[0].Issue, Is.Not.Null);
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
@@ -1,0 +1,124 @@
+using Atlassian.Jira;
+using Moq;
+using NUnit.Framework;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Dto;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class JiraTaskEventDataSourceTests
+    {
+        private Mock<IJiraService> _jiraServiceMock;
+        private Mock<IJiraQueryFactory> _queryFactoryMock;
+        private Mock<IIdentityService> _identityServiceMock;
+        private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
+        private IEventDataSource _sut;
+        private CancellationToken _ct;
+
+        [SetUp]
+        public void Setup()
+        {
+            _jiraServiceMock = new Mock<IJiraService>();
+            _queryFactoryMock = new Mock<IJiraQueryFactory>();
+            _identityServiceMock = new Mock<IIdentityService>();
+            _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
+            _sut = new JiraTaskEventDataSource(
+                _jiraServiceMock.Object,
+                _queryFactoryMock.Object,
+                _identityServiceMock.Object,
+                _userProfileStorageMock.Object);
+            _ct = CancellationToken.None;
+
+            _identityServiceMock
+                .Setup(x => x.GetCurrentUserAsync())
+                .ReturnsAsync(new Pet.Jira.Domain.Models.Users.User { Username = "user1" });
+
+            _userProfileStorageMock
+                .Setup(x => x.GetValueAsync("user1", _ct))
+                .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
+
+            _queryFactoryMock.Setup(x => x.Create()).Returns(new JiraQuery());
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenNoIssues_ReturnsEmptyList()
+        {
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto>());
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueChangeLogItemsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<IssueChangeLog, bool>>(),
+                    It.IsAny<Func<IssueChangeLogItem, bool>>(),
+                    _ct))
+                .ReturnsAsync(new List<IssueChangeLogItemDto>());
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenIssueHasTwoChangelogItems_ReturnsOneInterval()
+        {
+            var issue = new IssueDto { Key = "PROJ-1", Summary = "Fix bug", Link = "http://jira/PROJ-1" };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto> { issue });
+
+            var t0 = new DateTime(2026, 6, 1, 9, 0, 0);
+            var t1 = new DateTime(2026, 6, 1, 12, 0, 0);
+
+            var changelogItems = new List<IssueChangeLogItemDto>
+            {
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t0, Issue = issue },
+                    FromId = "1", ToId = "3"
+                },
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t1, Issue = issue },
+                    FromId = "3", ToId = "4"
+                }
+            };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueChangeLogItemsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<IssueChangeLog, bool>>(),
+                    It.IsAny<Func<IssueChangeLogItem, bool>>(),
+                    _ct))
+                .ReturnsAsync(changelogItems);
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Start, Is.EqualTo(t0));
+            Assert.That(result[0].End, Is.EqualTo(t1));
+            Assert.That(result[0].Source, Is.EqualTo(EventSource.Task));
+            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-1"));
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
@@ -1,8 +1,12 @@
 using Atlassian.Jira;
 using Moq;
 using NUnit.Framework;
+using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Application.Time;
 using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Events;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Dto;
@@ -19,6 +23,9 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
     {
         private Mock<IJiraService> _jiraServiceMock;
         private Mock<IJiraQueryFactory> _queryFactoryMock;
+        private Mock<IIdentityService> _identityServiceMock;
+        private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
+        private Mock<ITimeProvider> _timeProviderMock;
         private IEventDataSource _sut;
         private CancellationToken _ct;
 
@@ -27,10 +34,29 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
         {
             _jiraServiceMock = new Mock<IJiraService>();
             _queryFactoryMock = new Mock<IJiraQueryFactory>();
+            _identityServiceMock = new Mock<IIdentityService>();
+            _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
+            _timeProviderMock = new Mock<ITimeProvider>();
             _sut = new JiraTaskEventDataSource(
                 _jiraServiceMock.Object,
-                _queryFactoryMock.Object);
+                _queryFactoryMock.Object,
+                _identityServiceMock.Object,
+                _userProfileStorageMock.Object,
+                _timeProviderMock.Object);
             _ct = CancellationToken.None;
+
+            _identityServiceMock
+                .Setup(x => x.GetCurrentUserAsync())
+                .ReturnsAsync(new User { Username = "user1" });
+
+            _userProfileStorageMock
+                .Setup(x => x.GetValueAsync("user1", _ct))
+                .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
+
+            // Pass-through conversion so test times stay deterministic
+            _timeProviderMock
+                .Setup(x => x.ConvertToUserTimezone(It.IsAny<DateTime>(), It.IsAny<TimeZoneInfo>()))
+                .Returns((DateTime dt, TimeZoneInfo _) => dt);
 
             _queryFactoryMock.Setup(x => x.Create()).Returns(new JiraQuery());
         }
@@ -59,7 +85,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
         }
 
         [Test]
-        public async Task GetEventsAsync_WhenIssueHasTwoChangelogItems_ReturnsOneInterval()
+        public async Task GetEventsAsync_WhenIssueEntersAndLeavesInProgress_ReturnsInProgressInterval()
         {
             var issue = new IssueDto { Key = "PROJ-1", Summary = "Fix bug", Link = "http://jira/PROJ-1" };
 
@@ -72,15 +98,17 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
 
             var changelogItems = new List<IssueChangeLogItemDto>
             {
+                // -> In Progress (id 3)
                 new IssueChangeLogItemDto
                 {
                     ChangeLog = new IssueChangeLogDto { CreatedDate = t0, Issue = issue },
-                    FromId = "1", ToId = "3"
+                    FromId = "1", ToId = "3", Author = "user1"
                 },
+                // In Progress -> Done
                 new IssueChangeLogItemDto
                 {
                     ChangeLog = new IssueChangeLogDto { CreatedDate = t1, Issue = issue },
-                    FromId = "3", ToId = "4"
+                    FromId = "3", ToId = "4", Author = "user1"
                 }
             };
 
@@ -102,6 +130,48 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].End, Is.EqualTo(t1));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Task));
             Assert.That(result[0].IssueKey, Is.EqualTo("PROJ-1"));
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenChangeLogItemAuthoredByAnotherUser_IsExcluded()
+        {
+            var issue = new IssueDto { Key = "PROJ-1", Summary = "Fix bug", Link = "http://jira/PROJ-1" };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto> { issue });
+
+            var t0 = new DateTime(2026, 6, 1, 9, 0, 0);
+            var t1 = new DateTime(2026, 6, 1, 12, 0, 0);
+
+            var changelogItems = new List<IssueChangeLogItemDto>
+            {
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t0, Issue = issue },
+                    FromId = "1", ToId = "3", Author = "someone-else"
+                },
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t1, Issue = issue },
+                    FromId = "3", ToId = "4", Author = "someone-else"
+                }
+            };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueChangeLogItemsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<IssueChangeLog, bool>>(),
+                    It.IsAny<Func<IssueChangeLogItem, bool>>(),
+                    _ct))
+                .ReturnsAsync(changelogItems);
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
@@ -101,7 +101,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Start, Is.EqualTo(t0));
             Assert.That(result[0].End, Is.EqualTo(t1));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Task));
-            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-1"));
+            Assert.That(result[0].IssueKey, Is.EqualTo("PROJ-1"));
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTaskEventDataSourceTests.cs
@@ -1,11 +1,8 @@
 using Atlassian.Jira;
 using Moq;
 using NUnit.Framework;
-using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Events;
-using Pet.Jira.Application.Storage;
 using Pet.Jira.Domain.Models.Events;
-using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Events;
 using Pet.Jira.Infrastructure.Jira;
 using Pet.Jira.Infrastructure.Jira.Dto;
@@ -22,8 +19,6 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
     {
         private Mock<IJiraService> _jiraServiceMock;
         private Mock<IJiraQueryFactory> _queryFactoryMock;
-        private Mock<IIdentityService> _identityServiceMock;
-        private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
         private IEventDataSource _sut;
         private CancellationToken _ct;
 
@@ -32,22 +27,10 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
         {
             _jiraServiceMock = new Mock<IJiraService>();
             _queryFactoryMock = new Mock<IJiraQueryFactory>();
-            _identityServiceMock = new Mock<IIdentityService>();
-            _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
             _sut = new JiraTaskEventDataSource(
                 _jiraServiceMock.Object,
-                _queryFactoryMock.Object,
-                _identityServiceMock.Object,
-                _userProfileStorageMock.Object);
+                _queryFactoryMock.Object);
             _ct = CancellationToken.None;
-
-            _identityServiceMock
-                .Setup(x => x.GetCurrentUserAsync())
-                .ReturnsAsync(new Pet.Jira.Domain.Models.Users.User { Username = "user1" });
-
-            _userProfileStorageMock
-                .Setup(x => x.GetValueAsync("user1", _ct))
-                .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
 
             _queryFactoryMock.Setup(x => x.Create()).Returns(new JiraQuery());
         }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTesterEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTesterEventDataSourceTests.cs
@@ -1,0 +1,106 @@
+using Atlassian.Jira;
+using Moq;
+using NUnit.Framework;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Infrastructure.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Dto;
+using Pet.Jira.Infrastructure.Jira.Query;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class JiraTesterEventDataSourceTests
+    {
+        private Mock<IJiraService> _jiraServiceMock;
+        private Mock<IJiraQueryFactory> _queryFactoryMock;
+        private IEventDataSource _sut;
+        private CancellationToken _ct;
+
+        [SetUp]
+        public void Setup()
+        {
+            _jiraServiceMock = new Mock<IJiraService>();
+            _queryFactoryMock = new Mock<IJiraQueryFactory>();
+            _sut = new JiraTesterEventDataSource(
+                _jiraServiceMock.Object,
+                _queryFactoryMock.Object);
+            _ct = CancellationToken.None;
+
+            _queryFactoryMock.Setup(x => x.Create()).Returns(new JiraQuery());
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenNoIssues_ReturnsEmptyList()
+        {
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto>());
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueChangeLogItemsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<IssueChangeLog, bool>>(),
+                    It.IsAny<Func<IssueChangeLogItem, bool>>(),
+                    _ct))
+                .ReturnsAsync(new List<IssueChangeLogItemDto>());
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenIssueHasTesterChangelogItems_ReturnsEventIntervals()
+        {
+            var issue = new IssueDto { Key = "PROJ-2", Summary = "Test the feature", Link = "http://jira/PROJ-2" };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssuesAsync(It.IsAny<IssueSearchOptions>(), _ct))
+                .ReturnsAsync(new List<IssueDto> { issue });
+
+            var t0 = new DateTime(2026, 6, 1, 10, 0, 0);
+            var t1 = new DateTime(2026, 6, 1, 14, 0, 0);
+
+            var changelogItems = new List<IssueChangeLogItemDto>
+            {
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t0, Issue = issue },
+                    FromId = "3", ToId = "10116"
+                },
+                new IssueChangeLogItemDto
+                {
+                    ChangeLog = new IssueChangeLogDto { CreatedDate = t1, Issue = issue },
+                    FromId = "10116", ToId = "4"
+                }
+            };
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueChangeLogItemsAsync(
+                    It.IsAny<IEnumerable<IssueDto>>(),
+                    It.IsAny<Func<IssueChangeLog, bool>>(),
+                    It.IsAny<Func<IssueChangeLogItem, bool>>(),
+                    _ct))
+                .ReturnsAsync(changelogItems);
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Start, Is.EqualTo(t0));
+            Assert.That(result[0].End, Is.EqualTo(t1));
+            Assert.That(result[0].Source, Is.EqualTo(Pet.Jira.Domain.Models.Events.EventSource.Task));
+            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-2"));
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTesterEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/JiraTesterEventDataSourceTests.cs
@@ -100,7 +100,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Start, Is.EqualTo(t0));
             Assert.That(result[0].End, Is.EqualTo(t1));
             Assert.That(result[0].Source, Is.EqualTo(Pet.Jira.Domain.Models.Events.EventSource.Task));
-            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-2"));
+            Assert.That(result[0].IssueKey, Is.EqualTo("PROJ-2"));
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
@@ -2,9 +2,11 @@ using Moq;
 using NUnit.Framework;
 using Pet.Jira.Application.Authentication;
 using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Extensions;
 using Pet.Jira.Application.Extensions.YandexCalendar;
 using Pet.Jira.Application.Extensions.YandexCalendar.Dto;
 using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Entities.Extensions;
 using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Events;
@@ -20,6 +22,7 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
     {
         private Mock<IYandexCalendarService> _calendarServiceMock;
         private Mock<IYandexCalendarSettingsProvider> _settingsProviderMock;
+        private Mock<IUserExtensionRepository> _extensionRepositoryMock;
         private Mock<IIdentityService> _identityServiceMock;
         private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
         private IEventDataSource _sut;
@@ -30,11 +33,13 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
         {
             _calendarServiceMock = new Mock<IYandexCalendarService>();
             _settingsProviderMock = new Mock<IYandexCalendarSettingsProvider>();
+            _extensionRepositoryMock = new Mock<IUserExtensionRepository>();
             _identityServiceMock = new Mock<IIdentityService>();
             _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
             _sut = new YandexCalendarEventDataSource(
                 _calendarServiceMock.Object,
                 _settingsProviderMock.Object,
+                _extensionRepositoryMock.Object,
                 _identityServiceMock.Object,
                 _userProfileStorageMock.Object);
             _ct = CancellationToken.None;
@@ -46,10 +51,45 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             _userProfileStorageMock
                 .Setup(x => x.GetValueAsync("user1", _ct))
                 .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
+
+            _extensionRepositoryMock
+                .Setup(x => x.GetAsync("user1", ExtensionType.YandexCalendar, _ct))
+                .ReturnsAsync(new UserExtension { IsEnabled = true });
         }
 
         [Test]
-        public async Task GetEventsAsync_WhenSettingsNull_ReturnsEmptyList()
+        public async Task GetEventsAsync_WhenExtensionDisabled_ReturnsEmpty()
+        {
+            _extensionRepositoryMock
+                .Setup(x => x.GetAsync("user1", ExtensionType.YandexCalendar, _ct))
+                .ReturnsAsync(new UserExtension { IsEnabled = false });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+            _settingsProviderMock.Verify(x => x.GetSettingsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenExtensionNotConfigured_ReturnsEmpty()
+        {
+            _extensionRepositoryMock
+                .Setup(x => x.GetAsync("user1", ExtensionType.YandexCalendar, _ct))
+                .ReturnsAsync((UserExtension?)null);
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenSettingsNull_ReturnsEmpty()
         {
             _settingsProviderMock
                 .Setup(x => x.GetSettingsAsync("user1", _ct))
@@ -73,8 +113,8 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
 
             var calEvent = new YandexCalendarEventDto(
                 Summary: "Daily standup",
-                Start: new DateTime(2026, 6, 1, 9, 0, 0),
-                End: new DateTime(2026, 6, 1, 9, 30, 0),
+                Start: new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc),
+                End: new DateTime(2026, 6, 1, 9, 30, 0, DateTimeKind.Utc),
                 JiraIssueKeyHint: null,
                 Uid: null,
                 Description: null,
@@ -99,6 +139,40 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].End, Is.EqualTo(new DateTime(2026, 6, 1, 9, 30, 0)));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Calendar));
             Assert.That(result[0].Issue, Is.Null);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenEventMatchesExcludedPhrase_EventIsFiltered()
+        {
+            var settings = new YandexCalendarSettingsDto(
+                "login", "pass",
+                new[] { "Обед", "Lunch" },
+                Array.Empty<YandexCalendarIssueMapping>());
+            _settingsProviderMock
+                .Setup(x => x.GetSettingsAsync("user1", _ct))
+                .ReturnsAsync(settings);
+
+            var utcNow = new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+            _calendarServiceMock
+                .Setup(x => x.GetEventsAsync(
+                    It.IsAny<YandexCalendarCredentials>(),
+                    new DateOnly(2026, 6, 1),
+                    It.IsAny<TimeZoneInfo>(),
+                    _ct))
+                .ReturnsAsync(new List<YandexCalendarEventDto>
+                {
+                    new("Standup",        utcNow,              utcNow.AddMinutes(30), null, null, null, null),
+                    new("Обед с командой", utcNow.AddHours(3), utcNow.AddHours(4),    null, null, null, null),
+                    new("Team Lunch",     utcNow.AddHours(4), utcNow.AddHours(5),    null, null, null, null),
+                });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Title, Is.EqualTo("Standup"));
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
@@ -138,7 +138,41 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].Start, Is.EqualTo(new DateTime(2026, 6, 1, 9, 0, 0)));
             Assert.That(result[0].End, Is.EqualTo(new DateTime(2026, 6, 1, 9, 30, 0)));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Calendar));
-            Assert.That(result[0].Issue, Is.Null);
+            Assert.That(result[0].IssueKey, Is.Null);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenEventHasJiraIssueKeyHint_PopulatesIssueKey()
+        {
+            var settings = new YandexCalendarSettingsDto("login", "pass", Array.Empty<string>(), Array.Empty<YandexCalendarIssueMapping>());
+            _settingsProviderMock
+                .Setup(x => x.GetSettingsAsync("user1", _ct))
+                .ReturnsAsync(settings);
+
+            var calEvent = new YandexCalendarEventDto(
+                Summary: "PROJ-42 planning",
+                Start: new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc),
+                End: new DateTime(2026, 6, 1, 9, 30, 0, DateTimeKind.Utc),
+                JiraIssueKeyHint: "PROJ-42",
+                Uid: null,
+                Description: null,
+                Url: null);
+
+            _calendarServiceMock
+                .Setup(x => x.GetEventsAsync(
+                    It.IsAny<YandexCalendarCredentials>(),
+                    new DateOnly(2026, 6, 1),
+                    It.IsAny<TimeZoneInfo>(),
+                    _ct))
+                .ReturnsAsync(new List<YandexCalendarEventDto> { calEvent });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].IssueKey, Is.EqualTo("PROJ-42"));
         }
 
         [Test]

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
@@ -8,8 +8,6 @@ using Pet.Jira.Application.Storage;
 using Pet.Jira.Domain.Models.Events;
 using Pet.Jira.Domain.Models.Users;
 using Pet.Jira.Infrastructure.Events;
-using Pet.Jira.Infrastructure.Jira;
-using Pet.Jira.Infrastructure.Jira.Dto;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -24,7 +22,6 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
         private Mock<IYandexCalendarSettingsProvider> _settingsProviderMock;
         private Mock<IIdentityService> _identityServiceMock;
         private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
-        private Mock<IJiraService> _jiraServiceMock;
         private IEventDataSource _sut;
         private CancellationToken _ct;
 
@@ -35,13 +32,11 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             _settingsProviderMock = new Mock<IYandexCalendarSettingsProvider>();
             _identityServiceMock = new Mock<IIdentityService>();
             _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
-            _jiraServiceMock = new Mock<IJiraService>();
             _sut = new YandexCalendarEventDataSource(
                 _calendarServiceMock.Object,
                 _settingsProviderMock.Object,
                 _identityServiceMock.Object,
-                _userProfileStorageMock.Object,
-                _jiraServiceMock.Object);
+                _userProfileStorageMock.Object);
             _ct = CancellationToken.None;
 
             _identityServiceMock
@@ -101,42 +96,6 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
             Assert.That(result[0].End, Is.EqualTo(new DateTime(2026, 6, 1, 9, 30, 0)));
             Assert.That(result[0].Source, Is.EqualTo(EventSource.Calendar));
             Assert.That(result[0].Issue, Is.Null);
-        }
-
-        [Test]
-        public async Task GetEventsAsync_WhenEventHasIssueKeyHint_SetsIssue()
-        {
-            var settings = new YandexCalendarSettingsDto("login", "pass", Array.Empty<string>(), Array.Empty<YandexCalendarIssueMapping>());
-            _settingsProviderMock
-                .Setup(x => x.GetSettingsAsync("user1", _ct))
-                .ReturnsAsync(settings);
-
-            var calEvent = new YandexCalendarEventDto(
-                Summary: "Worked on PROJ-42",
-                Start: new DateTime(2026, 6, 1, 10, 0, 0),
-                End: new DateTime(2026, 6, 1, 11, 0, 0),
-                JiraIssueKeyHint: "PROJ-42");
-
-            _calendarServiceMock
-                .Setup(x => x.GetEventsAsync(
-                    It.IsAny<YandexCalendarCredentials>(),
-                    new DateOnly(2026, 6, 1),
-                    It.IsAny<TimeZoneInfo>(),
-                    _ct))
-                .ReturnsAsync(new List<YandexCalendarEventDto> { calEvent });
-
-            _jiraServiceMock
-                .Setup(x => x.GetIssueAsync("PROJ-42", _ct))
-                .ReturnsAsync(new IssueDto { Key = "PROJ-42", Summary = "Fix the thing", Link = "http://jira/PROJ-42" });
-
-            var result = await _sut.GetEventsAsync(
-                new DateOnly(2026, 6, 1),
-                new DateOnly(2026, 6, 1),
-                _ct);
-
-            Assert.That(result, Has.Count.EqualTo(1));
-            Assert.That(result[0].Issue, Is.Not.Null);
-            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-42"));
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
@@ -75,7 +75,10 @@ namespace Pet.Jira.UnitTests.Infrastructure.Events
                 Summary: "Daily standup",
                 Start: new DateTime(2026, 6, 1, 9, 0, 0),
                 End: new DateTime(2026, 6, 1, 9, 30, 0),
-                JiraIssueKeyHint: null);
+                JiraIssueKeyHint: null,
+                Uid: null,
+                Description: null,
+                Url: null);
 
             _calendarServiceMock
                 .Setup(x => x.GetEventsAsync(

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Events/YandexCalendarEventDataSourceTests.cs
@@ -1,0 +1,142 @@
+using Moq;
+using NUnit.Framework;
+using Pet.Jira.Application.Authentication;
+using Pet.Jira.Application.Events;
+using Pet.Jira.Application.Extensions.YandexCalendar;
+using Pet.Jira.Application.Extensions.YandexCalendar.Dto;
+using Pet.Jira.Application.Storage;
+using Pet.Jira.Domain.Models.Events;
+using Pet.Jira.Domain.Models.Users;
+using Pet.Jira.Infrastructure.Events;
+using Pet.Jira.Infrastructure.Jira;
+using Pet.Jira.Infrastructure.Jira.Dto;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.UnitTests.Infrastructure.Events
+{
+    [TestFixture]
+    public class YandexCalendarEventDataSourceTests
+    {
+        private Mock<IYandexCalendarService> _calendarServiceMock;
+        private Mock<IYandexCalendarSettingsProvider> _settingsProviderMock;
+        private Mock<IIdentityService> _identityServiceMock;
+        private Mock<IStorage<string, UserProfile>> _userProfileStorageMock;
+        private Mock<IJiraService> _jiraServiceMock;
+        private IEventDataSource _sut;
+        private CancellationToken _ct;
+
+        [SetUp]
+        public void Setup()
+        {
+            _calendarServiceMock = new Mock<IYandexCalendarService>();
+            _settingsProviderMock = new Mock<IYandexCalendarSettingsProvider>();
+            _identityServiceMock = new Mock<IIdentityService>();
+            _userProfileStorageMock = new Mock<IStorage<string, UserProfile>>();
+            _jiraServiceMock = new Mock<IJiraService>();
+            _sut = new YandexCalendarEventDataSource(
+                _calendarServiceMock.Object,
+                _settingsProviderMock.Object,
+                _identityServiceMock.Object,
+                _userProfileStorageMock.Object,
+                _jiraServiceMock.Object);
+            _ct = CancellationToken.None;
+
+            _identityServiceMock
+                .Setup(x => x.GetCurrentUserAsync())
+                .ReturnsAsync(new Pet.Jira.Domain.Models.Users.User { Username = "user1" });
+
+            _userProfileStorageMock
+                .Setup(x => x.GetValueAsync("user1", _ct))
+                .ReturnsAsync(new UserProfile { Username = "user1", TimeZoneId = "UTC" });
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenSettingsNull_ReturnsEmptyList()
+        {
+            _settingsProviderMock
+                .Setup(x => x.GetSettingsAsync("user1", _ct))
+                .ReturnsAsync((YandexCalendarSettingsDto?)null);
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenCalendarHasEvents_ReturnsMappedEvents()
+        {
+            var settings = new YandexCalendarSettingsDto("login", "pass", Array.Empty<string>(), Array.Empty<YandexCalendarIssueMapping>());
+            _settingsProviderMock
+                .Setup(x => x.GetSettingsAsync("user1", _ct))
+                .ReturnsAsync(settings);
+
+            var calEvent = new YandexCalendarEventDto(
+                Summary: "Daily standup",
+                Start: new DateTime(2026, 6, 1, 9, 0, 0),
+                End: new DateTime(2026, 6, 1, 9, 30, 0),
+                JiraIssueKeyHint: null);
+
+            _calendarServiceMock
+                .Setup(x => x.GetEventsAsync(
+                    It.IsAny<YandexCalendarCredentials>(),
+                    new DateOnly(2026, 6, 1),
+                    It.IsAny<TimeZoneInfo>(),
+                    _ct))
+                .ReturnsAsync(new List<YandexCalendarEventDto> { calEvent });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Title, Is.EqualTo("Daily standup"));
+            Assert.That(result[0].Start, Is.EqualTo(new DateTime(2026, 6, 1, 9, 0, 0)));
+            Assert.That(result[0].End, Is.EqualTo(new DateTime(2026, 6, 1, 9, 30, 0)));
+            Assert.That(result[0].Source, Is.EqualTo(EventSource.Calendar));
+            Assert.That(result[0].Issue, Is.Null);
+        }
+
+        [Test]
+        public async Task GetEventsAsync_WhenEventHasIssueKeyHint_SetsIssue()
+        {
+            var settings = new YandexCalendarSettingsDto("login", "pass", Array.Empty<string>(), Array.Empty<YandexCalendarIssueMapping>());
+            _settingsProviderMock
+                .Setup(x => x.GetSettingsAsync("user1", _ct))
+                .ReturnsAsync(settings);
+
+            var calEvent = new YandexCalendarEventDto(
+                Summary: "Worked on PROJ-42",
+                Start: new DateTime(2026, 6, 1, 10, 0, 0),
+                End: new DateTime(2026, 6, 1, 11, 0, 0),
+                JiraIssueKeyHint: "PROJ-42");
+
+            _calendarServiceMock
+                .Setup(x => x.GetEventsAsync(
+                    It.IsAny<YandexCalendarCredentials>(),
+                    new DateOnly(2026, 6, 1),
+                    It.IsAny<TimeZoneInfo>(),
+                    _ct))
+                .ReturnsAsync(new List<YandexCalendarEventDto> { calEvent });
+
+            _jiraServiceMock
+                .Setup(x => x.GetIssueAsync("PROJ-42", _ct))
+                .ReturnsAsync(new IssueDto { Key = "PROJ-42", Summary = "Fix the thing", Link = "http://jira/PROJ-42" });
+
+            var result = await _sut.GetEventsAsync(
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 1),
+                _ct);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Issue, Is.Not.Null);
+            Assert.That(result[0].Issue!.Key, Is.EqualTo("PROJ-42"));
+        }
+    }
+}

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Extensions/YandexCalendar/YandexCalDavServiceTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Extensions/YandexCalendar/YandexCalDavServiceTests.cs
@@ -71,7 +71,7 @@ END:VCALENDAR</C:calendar-data>
             public FakeHttpMessageHandler(string response) => _response = response;
 
             protected override Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request, CancellationToken ct)
+                HttpRequestMessage request, CancellationToken cancellationToken)
                 => Task.FromResult(new HttpResponseMessage(HttpStatusCode.MultiStatus)
                 {
                     Content = new StringContent(_response, System.Text.Encoding.UTF8, "application/xml")


### PR DESCRIPTION
@
## Summary
- Add `DayWorklogPlanner` (Application `IDayWorklogPlanner` + Infrastructure impl) computing a proposed loggable time per days events.
- Calendar events keep their exact real time; Task events split the remaining working time (`8h − Σ calendar`) proportionally to their durations, packed sequentially from 10:00, last task absorbs the remainder so the per-day total is exactly 8h.
- Add `ProposedWorklog` record (`Domain.Models.Planning`).
- Show the proposed time as a chip per event on the Events page.

First step toward evolving the Events page into a cleaner Worklogs architecture on the Event pipeline. Distribution mirrors the existing `WorkingDay.Refresh()`.

Out of scope (future): reading the working window/norm from `WorkingDaySettings` (currently hardcoded 8h / 10:00), subtracting already-logged actuals, logging to Jira.

## Test Plan
- [x] `DayWorklogPlanner` unit tests (8 cases)
- [x] Full suite green (107 tests)
- [ ] Manual: open the Events page, confirm proposed-time chips render and sum to 8h/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@