### PR TITLE
feat: replace updatedDate filter with WAS 'In Progress' DURING for assignee JQL

### DIFF
--- a/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
@@ -82,9 +82,9 @@ namespace Pet.Jira.Infrastructure.Jira
 			CancellationToken cancellationToken = default)
 		{
 			var issueQuery = _queryFactory.Create()
-				.Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, query.StartDate)
 				.Where("assignee", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
 				.Where("type", JiraQueryComparisonType.NotEqual, "Story")
+				.WhereWas("status", "In Progress", query.StartDate, query.EndDate)
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
 			var issueSearchOptions = new IssueSearchOptions(issueQuery)

--- a/src/Pet.Jira.Infrastructure/Jira/Query/JiraQuery.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/Query/JiraQuery.cs
@@ -8,12 +8,12 @@ namespace Pet.Jira.Infrastructure.Jira.Query
 {
     public class JiraQuery
     {
-        private readonly List<JiraQueryCondition> _conditions;
+        private readonly List<string> _conditions;
         private readonly List<JiraQueryOrder> _orders;
 
         public JiraQuery()
         {
-            _conditions = new List<JiraQueryCondition>();
+            _conditions = new List<string>();
             _orders = new List<JiraQueryOrder>();
         }
 
@@ -24,7 +24,19 @@ namespace Pet.Jira.Infrastructure.Jira.Query
                 Left = left,
                 ComparisonType = comparisonType,
                 Right = GetStringValue(right)
-            });
+            }.ToString());
+            return this;
+        }
+
+        public JiraQuery WhereWas(string field, string value, DateTime duringFrom, DateTime duringTo)
+        {
+            _conditions.Add(new JiraQueryWasCondition
+            {
+                Field = field,
+                Value = value,
+                DuringFrom = duringFrom,
+                DuringTo = duringTo
+            }.ToString());
             return this;
         }
 

--- a/src/Pet.Jira.Infrastructure/Jira/Query/JiraQueryWasCondition.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/Query/JiraQueryWasCondition.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+
+namespace Pet.Jira.Infrastructure.Jira.Query
+{
+    public class JiraQueryWasCondition
+    {
+        public string Field { get; set; }
+        public string Value { get; set; }
+        public DateTime DuringFrom { get; set; }
+        public DateTime DuringTo { get; set; }
+
+        public override string ToString()
+        {
+            var format = JiraQueryConstants.Date.DefaultFormat;
+            var from = DuringFrom.ToString(format, CultureInfo.InvariantCulture);
+            var to = DuringTo.ToString(format, CultureInfo.InvariantCulture);
+            return $"{Field} WAS '{Value}' DURING ('{from}', '{to}')";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #232

- Заменяет широкий фильтр `updatedDate >= startDate` на точный `status WAS 'In Progress' DURING (startDate, endDate)` в Assignee-треке
- Добавлен новый класс `JiraQueryWasCondition` для рендеринга WAS-условий
- В `JiraQuery` добавлен метод `WhereWas(field, value, from, to)`

Итоговый JQL:
```
assignee = currentUser() AND type != 'Story' AND status WAS 'In Progress' DURING ('...', '...') ORDER BY updatedDate DESC
```

## Why

Предыдущий фильтр возвращал все задачи пользователя, обновлённые с начала периода — включая задачи с любыми изменениями (комментарии, поля). `WAS "In Progress" DURING` точно выбирает задачи, которые реально находились в работе в указанный период, включая задачи, стартовавшие до начала периода.

## Test plan

- [ ] `dotnet test` — все 95 тестов зелёные
- [ ] Проверить в UI: Assignee-задачи соответствуют реально работавшим issue за период
- [ ] Граничный случай: задача уже была в "In Progress" до начала периода — должна отображаться

🤖 Generated with [Claude Code](https://claude.com/claude-code)