### PR TITLE
feat: add CalendarWorklogMenu with Create worklog action for calendar events

### DIFF
--- a/src/Pet.Jira.Application/Worklogs/Dto/WorkingDayWorklog.cs
+++ b/src/Pet.Jira.Application/Worklogs/Dto/WorkingDayWorklog.cs
@@ -129,6 +129,9 @@ namespace Pet.Jira.Application.Worklogs.Dto
 
             result.UpdateRemainingTimeSpent(result.TimeSpent);
 
+            if (result.Source == WorklogSource.Calendar && result.Issue?.Summary != null)
+                result.Comment = result.Issue.Summary;
+
             return result;
         }
 

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor
@@ -2,7 +2,9 @@
 
 <MudElement Class="gap-2 d-flex flex-wrap border-none align-center">
     <MudElement Class="flex-auto d-flex gap-1 align-center" Style="width: 300px">
-        <MudElement Style="width:28px" />
+        <CalendarWorklogMenu Entity="@Entity"
+                             Color="Color.Tertiary"
+                             OnCreatedPressed="OnMenuCreatedPressed" />
         <MudIcon Icon="@Icons.Material.Filled.Event"
                  Color="Color.Tertiary"
                  Size="Size.Small" />

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor.cs
@@ -9,6 +9,7 @@ namespace Pet.Jira.Web.Components.Worklogs
         [Parameter] public WorkingDayWorklog Entity { get; set; } = default!;
         [Parameter] public bool IsLogged { get; set; }
         [Parameter] public EventCallback<WorkingDayWorklog> OnAddPressed { get; set; }
+        [Parameter] public EventCallback<WorkingDayWorklog> OnMenuCreatedPressed { get; set; }
 
         private string Title => Entity.Issue?.Summary ?? Entity.Comment ?? string.Empty;
 

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogMenu.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogMenu.razor
@@ -1,0 +1,15 @@
+@using MudBlazor
+
+<MudMenu Icon="@Icons.Material.Filled.MoreVert"
+         Color="@Color"
+         Size="Size.Small"
+         Dense="true"
+         Class="pet-vertical-align-middle"
+         AnchorOrigin="Origin.BottomLeft"
+         TransformOrigin="Origin.TopLeft">
+    <ChildContent>
+        <MudMenuItem OnClick="(async () => await CreateWorklogAsync())">Create worklog</MudMenuItem>
+    </ChildContent>
+</MudMenu>
+
+@code {}

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogMenu.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogMenu.razor.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pet.Jira.Application.Worklogs.Dto;
+using Pet.Jira.Web.Shared;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Web.Components.Worklogs
+{
+    public partial class CalendarWorklogMenu : ComponentBase
+    {
+        [Parameter] public WorkingDayWorklog Entity { get; set; } = default!;
+        [Parameter] public EventCallback<WorkingDayWorklog> OnCreatedPressed { get; set; }
+        [Parameter] public Color Color { get; set; } = Color.Tertiary;
+
+        [CascadingParameter] public ErrorHandler ErrorHandler { get; set; } = default!;
+
+        [Inject] private IDialogService DialogService { get; set; } = default!;
+
+        private async Task CreateWorklogAsync()
+        {
+            var parameters = new DialogParameters
+            {
+                { nameof(WorklogDayItemDialog.WorklogTemplate), Entity }
+            };
+            var dialog = await DialogService.ShowAsync<WorklogDayItemDialog>("Add worklog", parameters);
+            var result = await dialog.Result;
+            if (result?.Data is WorkingDayWorklog created)
+                await OnCreatedPressed.InvokeAsync(created);
+        }
+    }
+}

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDay.razor
@@ -46,7 +46,8 @@
                     : row.CalendarWorklog.ChildrenTimeSpent > TimeSpan.Zero;
                 <CalendarWorklogItem Entity="@row.CalendarWorklog"
                                      IsLogged="@isLogged"
-                                     OnAddPressed="CalendarAddAsync" />
+                                     OnAddPressed="CalendarAddAsync"
+                                     OnMenuCreatedPressed="AddWorklogAsync" />
                 @foreach (var child in row.CalendarWorklog.Children)
                 {
                     <EstimatedActualWorklogItem Entity="@child" />


### PR DESCRIPTION
## Summary

- Adds CalendarWorklogMenu component (mirrors WorklogMenu pattern) with a MoreVert context menu on all calendar event rows
- Menu item "Create worklog" opens WorklogDayItemDialog with date, time, issue (if keyed), and comment pre-filled from the event — user can override any field
- WorkingDayWorklog.CreateEstimated now sets Comment from Issue.Summary for Calendar-sourced worklogs
- Closes #235

## Test plan

- [ ] Keyed calendar event: menu appears, dialog opens with all fields pre-filled; user can change issue and log
- [ ] Keyless calendar event: dialog opens with time pre-filled, issue field empty
- [ ] Plus button still logs directly without dialog (existing behaviour unchanged)
- [ ] Cancelling the dialog does not log anything

Generated with Claude Code