### PR TITLE
fix: expand day header highlight to full row width

### DIFF
--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogList.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogList.razor
@@ -51,8 +51,8 @@
         background-color: inherit;
     }
 
-    .pet-table-summary-tr {
-        background-color: var(--mud-palette-background-grey);
+    .pet-table-summary-tr td {
+        padding: 0 !important;
     }
 </style>
 

--- a/src/Pet.Jira.Web/wwwroot/css/site.css
+++ b/src/Pet.Jira.Web/wwwroot/css/site.css
@@ -161,7 +161,7 @@ app {
     padding: 8px 12px;
     border-left: 3px solid var(--mud-palette-divider);
     background: var(--mud-palette-background-grey);
-    border-radius: 0 8px 8px 0;
+    border-radius: 0;
 }
 .pet-day-header-done {
     border-left-color: var(--mud-palette-success);


### PR DESCRIPTION
## Summary

- Remove `padding` from `.pet-table-summary-tr td` so `pet-day-header` div stretches edge-to-edge across the full table row
- Remove right `border-radius` from `.pet-day-header` that clipped corners at full width

## Root cause

The `<td>` had `padding: 4px 14px` applied via the global dense-table rule, leaving 14px gaps on each side of the header background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)