### PR TITLE
fix: eliminate hover oscillation on extension cards

### DIFF
--- a/src/Pet.Jira.Web/Components/Extensions/ExtensionsPage.razor
+++ b/src/Pet.Jira.Web/Components/Extensions/ExtensionsPage.razor
@@ -1,5 +1,7 @@
 @using Pet.Jira.Web.Components.Extensions.YandexCalendar
 
 <div class="extv-glow__grid">
-    <YandexCalendarExtensionCard/>
+    <div class="extv-glow__outer">
+        <YandexCalendarExtensionCard/>
+    </div>
 </div>

--- a/src/Pet.Jira.Web/wwwroot/css/custom.css
+++ b/src/Pet.Jira.Web/wwwroot/css/custom.css
@@ -110,6 +110,9 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 20px;
 }
+.extv-glow__outer {
+    padding-bottom: 5px;
+}
 .extv-glow__card {
     position: relative;
     display: flex;
@@ -131,12 +134,12 @@
     transition: opacity .3s ease;
     pointer-events: none;
 }
-.extv-glow__card:hover {
+.extv-glow__outer:hover .extv-glow__card {
     transform: translateY(-5px);
     border-color: var(--mud-palette-primary);
     box-shadow: 0 18px 40px -20px rgba(var(--mud-palette-primary-rgb), .55);
 }
-.extv-glow__card:hover::before { opacity: 1; }
+.extv-glow__outer:hover .extv-glow__card::before { opacity: 1; }
 .extv-glow__card--on { border-color: rgba(var(--mud-palette-success-rgb), .5); }
 .extv-glow__card--soon { border-style: dashed; }
 .extv-glow__card-top { display: flex; align-items: flex-start; justify-content: space-between; }
@@ -220,5 +223,9 @@
 @keyframes nav-badge-pulse {
     0%, 100% { box-shadow: 0 0 6px rgba(var(--mud-palette-primary-rgb), .35); }
     50%       { box-shadow: 0 0 12px rgba(var(--mud-palette-primary-rgb), .65), 0 0 18px rgba(var(--mud-palette-primary-rgb), .2); }
+}
+@keyframes ext-pulse {
+    0%, 100% { box-shadow: 0 0 9px var(--mud-palette-success); }
+    50%       { box-shadow: 0 0 16px var(--mud-palette-success), 0 0 24px rgba(var(--mud-palette-success-rgb), .4); }
 }
 


### PR DESCRIPTION
## Summary

- Fixes hover oscillation (UI jitter) on `.extv-glow__card` in the Extensions page
- Applies wrapper pattern: `.extv-glow__outer` acts as the static hover target, the inner card transforms via `.extv-glow__outer:hover .extv-glow__card`
- Adds missing `@keyframes ext-pulse` — the connected LED indicator animation was silently broken

## Root cause

`transform: translateY(-5px)` was applied directly on `.extv-glow__card:hover`. When the cursor hovered near the card's bottom border, the card would lift up, exit the cursor, drop back down, and re-enter the cursor — creating a rapid oscillation loop.

## Test plan

- [ ] Hover near the bottom/side border of an extension card — no jitter
- [ ] The hover lift animation still works smoothly
- [ ] On a connected Yandex Calendar card, the LED dot pulses (animation now defined)
- [ ] Card states `--on` and `--soon` display correctly

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)