### PR TITLE
feat: show loading spinner on worklog add button while saving (#238)

### DIFF
--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor
@@ -36,12 +36,21 @@
                           Class="pet-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
-            <MudIconButton Size="Size.Small"
-                           Icon="@Icons.Material.Filled.Add"
-                           Variant="Variant.Filled"
-                           Color="Color.Tertiary"
-                           OnClick="AddAsync"
-                           Disabled="@Entity.IsEmpty" />
+            @if (_isAdding)
+            {
+                <MudElement Class="d-flex align-center justify-center" Style="width:30px;height:30px">
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Color="Color.Tertiary" />
+                </MudElement>
+            }
+            else
+            {
+                <MudIconButton Size="Size.Small"
+                               Icon="@Icons.Material.Filled.Add"
+                               Variant="Variant.Filled"
+                               Color="Color.Tertiary"
+                               OnClick="AddAsync"
+                               Disabled="@Entity.IsEmpty" />
+            }
         </MudElement>
     </MudElement>
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/CalendarWorklogItem.razor.cs
@@ -18,12 +18,23 @@ namespace Pet.Jira.Web.Components.Worklogs
             !string.IsNullOrEmpty(Entity.Issue.Key) &&
             !Entity.IsEmpty;
 
+        private bool _isAdding;
+
         private async Task AddAsync()
         {
-            var worklog = IsReadyToLog
-                ? WorkingDayWorklog.CreateActualByEstimated(Entity)
-                : Entity;
-            await OnAddPressed.InvokeAsync(worklog);
+            _isAdding = true;
+            StateHasChanged();
+            try
+            {
+                var worklog = IsReadyToLog
+                    ? WorkingDayWorklog.CreateActualByEstimated(Entity)
+                    : Entity;
+                await OnAddPressed.InvokeAsync(worklog);
+            }
+            finally
+            {
+                _isAdding = false;
+            }
         }
     }
 }

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogItem.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogItem.razor
@@ -21,12 +21,21 @@
                           Class="pet-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
-            <MudIconButton Size="Size.Small"
-                       Icon="@Icons.Material.Filled.Add"
-                       Variant="Variant.Filled"
-                       Color="@Color"
-                       OnClick="AddAsync"
-                       Disabled="@Entity.IsEmpty"></MudIconButton>
+            @if (_isAdding)
+            {
+                <MudElement Class="d-flex align-center justify-center" Style="width:30px;height:30px">
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Color="@Color" />
+                </MudElement>
+            }
+            else
+            {
+                <MudIconButton Size="Size.Small"
+                           Icon="@Icons.Material.Filled.Add"
+                           Variant="Variant.Filled"
+                           Color="@Color"
+                           OnClick="AddAsync"
+                           Disabled="@Entity.IsEmpty"></MudIconButton>
+            }
         </MudElement>
     </MudElement>
 </MudElement>

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogItem.razor.cs
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogItem.razor.cs
@@ -14,10 +14,21 @@ namespace Pet.Jira.Web.Components.Worklogs
 
         [CascadingParameter] public ErrorHandler ErrorHandler { get; set; }
 
+        private bool _isAdding;
+
         private async Task AddAsync()
         {
-            var worklog = WorkingDayWorklog.CreateActualByEstimated(Entity);
-            await OnAddPressed.InvokeAsync(worklog);
+            _isAdding = true;
+            StateHasChanged();
+            try
+            {
+                var worklog = WorkingDayWorklog.CreateActualByEstimated(Entity);
+                await OnAddPressed.InvokeAsync(worklog);
+            }
+            finally
+            {
+                _isAdding = false;
+            }
         }
 
         private async Task AddCustomAsync(WorkingDayWorklog worklog)


### PR DESCRIPTION
## Описание

Closes #238

Улучшает UX добавления ворклога: при нажатии «+» кнопка заменяется локальным спиннером и блокируется на время запроса. Пользователь видит, что ворклог сохраняется, и не может отправить запрос повторно двойным кликом.

## Изменения

- `WorklogItem` (оценочные ворклоги) и `CalendarWorklogItem` (события календаря): кнопка «+» во время сохранения заменяется на `MudProgressCircular`.
- Состояние (`_isAdding`) управляется локально внутри каждого item-компонента вокруг ожидаемого `OnAddPressed` callback — изменения в родителе `WorklogDay` не потребовались.
- `StateHasChanged()` вызывается до `await`, чтобы спиннер появлялся в начале запроса, а не после.
- Спиннер обёрнут в контейнер `30×30px` по габаритам кнопки — без скачка верстки.

## Проверка

- `dotnet build` — успешно, 0 ошибок/предупреждений.
- Проверено вживую: спиннер отображается на месте «+» во время сохранения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)