### PR TITLE
feat: широкий hero-макет для витрин возможностей

### DIFF
--- a/src/Pet.Jira.Web/Components/Features/FeatureCard.razor
+++ b/src/Pet.Jira.Web/Components/Features/FeatureCard.razor
@@ -1,7 +1,11 @@
 @using Pet.Jira.Web.Components.Markdown
 
-<div class="extv-glow__outer feat-card" @onclick="OpenDetailAsync">
-    <MudPaper Elevation="0" Class="extv-glow__card">
+<div class="extv-glow__outer feat-card @(Featured ? "extv-glow__outer--hero" : null)" @onclick="OpenDetailAsync">
+    <MudPaper Elevation="0" Class="@CardClass">
+        @if (Featured)
+        {
+            <MudIcon Icon="@Icons.Material.Outlined.AutoAwesome" Class="extv-glow__ghost" />
+        }
         <div class="extv-glow__card-top">
             <div class="extv-glow__icon">
                 <MudIcon Icon="@Icons.Material.Outlined.AutoAwesome" />
@@ -15,11 +19,21 @@
             }
         </div>
 
-        <MudText Typo="Typo.h6" Class="mt-3" Style="font-weight:600">@Feature.Metadata.Title</MudText>
+        <MudText Typo="@(Featured ? Typo.h5 : Typo.h6)" Class="mt-3" Style="font-weight:600">@Feature.Metadata.Title</MudText>
 
         <div class="feat-card__preview mt-1">
             <MudMarkdown Value="@Feature.PreviewMarkdown" />
         </div>
+
+        @if (Featured && Feature.Metadata.Tags.Count > 0)
+        {
+            <div class="feat-card__tags mt-3">
+                @foreach (var tag in Feature.Metadata.Tags)
+                {
+                    <span class="feat-card__tag">@tag</span>
+                }
+            </div>
+        }
 
         <div class="extv-glow__foot">
             <span class="feat-card__date">

--- a/src/Pet.Jira.Web/Components/Features/FeatureDialogs.cs
+++ b/src/Pet.Jira.Web/Components/Features/FeatureDialogs.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pet.Jira.Web.Shared;
+using System;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Web.Components.Features
+{
+    /// <summary>
+    /// Shared helper for opening a feature's detail dialog. Used by both
+    /// <see cref="FeatureCard"/> and <see cref="FeatureHero"/> so the load-and-show
+    /// logic lives in one place.
+    /// </summary>
+    internal static class FeatureDialogs
+    {
+        public static async Task OpenDetailAsync(
+            FeatureSummary feature,
+            IFeatureCatalogService catalog,
+            IDialogService dialogService,
+            ErrorHandler errorHandler)
+        {
+            try
+            {
+                var detail = await catalog.GetFeatureAsync(feature.Metadata.Id);
+                if (detail is null)
+                {
+                    return;
+                }
+
+                var parameters = new DialogParameters
+                {
+                    { nameof(FeatureDetailDialog.Detail), detail }
+                };
+                var options = new DialogOptions
+                {
+                    MaxWidth = MaxWidth.Medium,
+                    FullWidth = true,
+                    CloseButton = true
+                };
+                await dialogService.ShowAsync<FeatureDetailDialog>(detail.Metadata.Title, parameters, options);
+            }
+            catch (Exception e)
+            {
+                errorHandler.ProcessError(e);
+            }
+        }
+    }
+}

--- a/src/Pet.Jira.Web/Components/Features/FeatureHero.razor
+++ b/src/Pet.Jira.Web/Components/Features/FeatureHero.razor
@@ -1,0 +1,54 @@
+@using Pet.Jira.Web.Components.Markdown
+
+<div class="feat-hero" @onclick="OpenDetailAsync">
+    <div class="feat-hero__body">
+        @if (IsNew)
+        {
+            <div class="extv-glow__status extv-glow__status--available feat-hero__badge">
+                <span class="extv-glow__led"></span>
+                Новинка
+            </div>
+        }
+        else if (Feature.Metadata.IsHighlighted)
+        {
+            <div class="extv-glow__status extv-glow__status--available feat-hero__badge">
+                <span class="extv-glow__led"></span>
+                Рекомендуем
+            </div>
+        }
+
+        <MudText Typo="Typo.h4" Class="feat-hero__title" Style="font-weight:700">@Feature.Metadata.Title</MudText>
+
+        <div class="feat-hero__preview feat-card__preview mt-2">
+            <MudMarkdown Value="@Feature.PreviewMarkdown" />
+        </div>
+
+        @if (Feature.Metadata.Tags.Count > 0)
+        {
+            <div class="feat-card__tags mt-4">
+                @foreach (var tag in Feature.Metadata.Tags)
+                {
+                    <span class="feat-card__tag">@tag</span>
+                }
+            </div>
+        }
+
+        <div class="feat-hero__foot mt-4">
+            <span class="feat-card__date">
+                <MudIcon Icon="@Icons.Material.Outlined.CalendarToday" Size="Size.Small" Class="feat-card__date-icon" />
+                @Feature.Metadata.Date.ToString("dd.MM.yyyy")
+            </span>
+            <span @onclick:stopPropagation="true">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                           EndIcon="@Icons.Material.Filled.ArrowForward"
+                           OnClick="OpenDetailAsync">
+                    Подробнее
+                </MudButton>
+            </span>
+        </div>
+    </div>
+
+    <div class="feat-hero__art">
+        <MudIcon Icon="@Icons.Material.Outlined.AutoAwesome" Class="feat-hero__art-glyph" />
+    </div>
+</div>

--- a/src/Pet.Jira.Web/Components/Features/FeatureHero.razor.cs
+++ b/src/Pet.Jira.Web/Components/Features/FeatureHero.razor.cs
@@ -6,18 +6,16 @@ using System.Threading.Tasks;
 
 namespace Pet.Jira.Web.Components.Features
 {
-    public partial class FeatureCard : ComponentBase
+    /// <summary>
+    /// Full-width horizontal hero banner for the most prominent feature at the top
+    /// of the catalog. Shares the click-to-open-detail behaviour with
+    /// <see cref="FeatureCard"/> via <see cref="FeatureDialogs"/>.
+    /// </summary>
+    public partial class FeatureHero : ComponentBase
     {
         private const int NewThresholdDays = 14;
 
         [Parameter] public FeatureSummary Feature { get; set; } = default!;
-
-        /// <summary>
-        /// When <c>true</c>, the card renders as a large hero panel (used for the
-        /// first feature in the bento layout): bigger icon/title, decorative glyph
-        /// and tag chips.
-        /// </summary>
-        [Parameter] public bool Featured { get; set; }
 
         [Inject] private IFeatureCatalogService FeatureCatalogService { get; init; } = default!;
         [Inject] private IDialogService DialogService { get; init; } = default!;
@@ -25,9 +23,6 @@ namespace Pet.Jira.Web.Components.Features
 
         private bool IsNew =>
             Feature.Metadata.Date >= DateOnly.FromDateTime(DateTime.Today).AddDays(-NewThresholdDays);
-
-        private string CardClass =>
-            Featured ? "extv-glow__card extv-glow__card--hero" : "extv-glow__card";
 
         private Task OpenDetailAsync() =>
             FeatureDialogs.OpenDetailAsync(Feature, FeatureCatalogService, DialogService, ErrorHandler);

--- a/src/Pet.Jira.Web/Components/Features/FeaturesPage.razor
+++ b/src/Pet.Jira.Web/Components/Features/FeaturesPage.razor
@@ -10,11 +10,14 @@
 
     @if (_isLoading)
     {
-        <div class="extv-glow__grid mt-5">
-            @for (var i = 0; i < 3; i++)
-            {
-                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="210px" Class="feat-page__skeleton" />
-            }
+        <div class="feat-catalog mt-5">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="260px" Class="feat-page__skeleton" />
+            <div class="extv-glow__grid">
+                @for (var i = 0; i < 3; i++)
+                {
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="210px" Class="feat-page__skeleton" />
+                }
+            </div>
         </div>
     }
     else if (_features.Count == 0)
@@ -23,10 +26,17 @@
     }
     else
     {
-        <div class="extv-glow__grid mt-5">
-            @foreach (var feature in _features)
+        <div class="feat-catalog mt-5">
+            <FeatureHero Feature="_features[0]" />
+
+            @if (_features.Count > 1)
             {
-                <FeatureCard Feature="feature" />
+                <div class="extv-glow__grid">
+                    @for (var i = 1; i < _features.Count; i++)
+                    {
+                        <FeatureCard Feature="_features[i]" />
+                    }
+                </div>
             }
         </div>
     }

--- a/src/Pet.Jira.Web/Components/Features/LatestFeaturesViewer.razor
+++ b/src/Pet.Jira.Web/Components/Features/LatestFeaturesViewer.razor
@@ -22,10 +22,10 @@ else
             </MudLink>
         </div>
 
-        <div class="extv-glow__grid mt-4">
-            @foreach (var feature in _features)
+        <div class="feat-promo__bento mt-4" data-count="@_features.Count">
+            @for (var i = 0; i < _features.Count; i++)
             {
-                <FeatureCard Feature="feature" />
+                <FeatureCard Feature="_features[i]" Featured="@(i == 0)" />
             }
         </div>
     </div>

--- a/src/Pet.Jira.Web/wwwroot/css/custom.css
+++ b/src/Pet.Jira.Web/wwwroot/css/custom.css
@@ -281,6 +281,205 @@
     white-space: nowrap;
 }
 
+/* ------------------------------------------------------------
+   Bento layout for the latest-features promo.
+   Narrow screens: a plain vertical stack.
+   Wide screens: the first feature becomes a tall "hero" panel
+   on the left; the remaining cards stack on the right.
+   ------------------------------------------------------------ */
+.feat-promo__bento {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+}
+.feat-promo__bento > .extv-glow__outer {
+    min-width: 0; /* let grid items shrink instead of overflowing */
+    animation: feat-rise .5s cubic-bezier(.2,.7,.2,1) both;
+}
+.feat-promo__bento > .extv-glow__outer:nth-child(1) { animation-delay: .04s; }
+.feat-promo__bento > .extv-glow__outer:nth-child(2) { animation-delay: .12s; }
+.feat-promo__bento > .extv-glow__outer:nth-child(3) { animation-delay: .20s; }
+
+@keyframes feat-rise {
+    from { opacity: 0; transform: translateY(14px); }
+    to   { opacity: 1; transform: none; }
+}
+
+@media (min-width: 1000px) {
+    .feat-promo__bento[data-count="3"] {
+        grid-template-columns: 1.55fr 1fr;
+        grid-template-rows: repeat(2, minmax(0, 1fr));
+    }
+    .feat-promo__bento[data-count="3"] > .extv-glow__outer:first-child {
+        grid-row: 1 / span 2;
+    }
+    .feat-promo__bento[data-count="2"] {
+        grid-template-columns: 1.55fr 1fr;
+    }
+    /* Hero cell stretches; make the card fill its full height. */
+    .feat-promo__bento .extv-glow__outer--hero,
+    .feat-promo__bento .extv-glow__outer--hero .extv-glow__card {
+        height: 100%;
+    }
+}
+
+/* Hero card enrichment */
+.extv-glow__card--hero {
+    background:
+        radial-gradient(120% 90% at 100% 0%, rgba(var(--mud-palette-primary-rgb), .16), transparent 58%),
+        var(--mud-palette-surface);
+    border-color: rgba(var(--mud-palette-primary-rgb), .35);
+}
+.extv-glow__card--hero .extv-glow__icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
+}
+.extv-glow__card--hero .feat-card__preview {
+    font-size: .95rem;
+    max-width: 46ch;
+}
+.extv-glow__ghost {
+    position: absolute;
+    top: -34px;
+    right: -26px;
+    width: 200px !important;
+    height: 200px !important;
+    color: rgba(var(--mud-palette-primary-rgb), .07);
+    transform: rotate(-8deg);
+    pointer-events: none;
+    z-index: 0;
+}
+.extv-glow__card--hero > *:not(.extv-glow__ghost) {
+    position: relative;
+    z-index: 1;
+}
+
+/* Tag chips (hero only) */
+.feat-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+}
+.feat-card__tag {
+    padding: 3px 11px;
+    border-radius: 999px;
+    font-size: .7rem;
+    font-weight: 600;
+    letter-spacing: .02em;
+    color: var(--mud-palette-text-secondary);
+    background: rgba(128, 128, 128, .1);
+    border: 1px solid var(--mud-palette-lines-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .feat-promo__bento > .extv-glow__outer { animation: none; }
+}
+
+/* ------------------------------------------------------------
+   Features catalog page: a full-width hero banner for the top
+   feature, followed by the standard responsive card grid.
+   ------------------------------------------------------------ */
+.feat-catalog {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
+.feat-hero {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 30px;
+    border-radius: 20px;
+    cursor: pointer;
+    overflow: hidden;
+    background:
+        radial-gradient(90% 130% at 100% -10%, rgba(var(--mud-palette-primary-rgb), .18), transparent 55%),
+        var(--mud-palette-surface);
+    border: 1px solid rgba(var(--mud-palette-primary-rgb), .32);
+    transition: transform .3s cubic-bezier(.2,.7,.2,1), border-color .3s ease, box-shadow .3s ease;
+    animation: feat-rise .5s cubic-bezier(.2,.7,.2,1) both;
+}
+.feat-hero:hover {
+    transform: translateY(-4px);
+    border-color: var(--mud-palette-primary);
+    box-shadow: 0 26px 55px -26px rgba(var(--mud-palette-primary-rgb), .6);
+}
+.feat-hero__body {
+    position: relative;
+    z-index: 1;
+    min-width: 0;
+    max-width: 680px;
+}
+.feat-hero__badge { margin-bottom: 14px; }
+.feat-hero__title { line-height: 1.15; }
+.feat-hero__preview { font-size: 1rem; max-width: 62ch; }
+.feat-hero__foot {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+
+/* Decorative "orb" artwork — hidden on narrow screens, revealed when wide. */
+.feat-hero__art { display: none; }
+
+@media (min-width: 1000px) {
+    .feat-hero {
+        grid-template-columns: 1.5fr .85fr;
+        align-items: center;
+        padding: 40px 46px;
+    }
+    .feat-hero__art {
+        position: relative;
+        display: grid;
+        place-items: center;
+        align-self: stretch;
+        min-height: 210px;
+    }
+    .feat-hero__art::before,
+    .feat-hero__art::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        border-radius: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+    }
+    .feat-hero__art::before {
+        width: 270px;
+        height: 270px;
+        border: 1px solid rgba(var(--mud-palette-primary-rgb), .18);
+    }
+    .feat-hero__art::after {
+        width: 190px;
+        height: 190px;
+        background: radial-gradient(circle, rgba(var(--mud-palette-primary-rgb), .16), transparent 70%);
+    }
+    .feat-hero__art-glyph {
+        position: relative;
+        z-index: 1;
+        width: 150px !important;
+        height: 150px !important;
+        color: rgba(var(--mud-palette-primary-rgb), .55);
+        filter: drop-shadow(0 10px 34px rgba(var(--mud-palette-primary-rgb), .4));
+        animation: feat-hero-float 6s ease-in-out infinite;
+    }
+}
+
+@keyframes feat-hero-float {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(-9px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .feat-hero { animation: none; }
+    .feat-hero__art-glyph { animation: none; }
+}
+
 /* Feature detail dialog */
 .feat-detail__meta {
     display: flex;


### PR DESCRIPTION
## Что и зачем

Обе витрины возможностей на широком экране выглядели как мелкая полоса из одинаковых карточек, прижатая к верху, с большой пустотой под ней. Ширина не работала на композицию, иерархии не было. Переработал оба экрана в редакторский макет с явной главной фичей.

## Изменения

### Промо в пустом состоянии ворклогов (`LatestFeaturesViewer`)
- Асимметричный **bento**: свежая фича становится высокой hero-панелью слева (крупнее иконка и заголовок, декоративный ghost-глиф, чипы-теги, усиленный glow), две остальные компактно стакаются справа.
- Корректная деградация: 3 фичи → hero + 2, 2 → hero + 1, 1 → hero на всю ширину, узкий экран → вертикальный стек.

### Каталог `/features`
- **Широкий горизонтальный hero-баннер** сверху для главной (highlighted/свежей) фичи: бейдж «Новинка»/«Рекомендуем» с LED-индикатором, крупный заголовок, превью, теги, дата и заметная filled-кнопка «Подробнее». Справа — декоративный «орб» (концентрические кольца + светящийся sparkle-глиф с лёгкой плавающей анимацией).
- Ниже — привычная адаптивная сетка остальных карточек. Масштабируется на любое число фич; при единственной фиче показывается только баннер.
- Скелетон загрузки обновлён под новый макет.

### Рефакторинг
- Логика открытия детального диалога вынесена в общий `FeatureDialogs`; `FeatureCard` и новый `FeatureHero` больше не дублируют её.

## Детали
- Все цвета — из палитры MudBlazor (`--mud-palette-*`), поэтому светлая/тёмная темы работают автоматически.
- Staggered-появление карточек на загрузке; учтён `prefers-reduced-motion`.

## Проверка (mock-режим)
- **1680px:** hero на всю ширину (колонки 1.5fr/.85fr), «орб» виден, бейдж/заголовок/теги рендерятся, ниже 4 карточки (5 − 1 hero); промо-bento — hero ровно на два ряда правых карточек.
- **375px:** «орб» скрыт, hero и сетка в одну колонку.
- Сборка: 0 предупреждений, консоль без ошибок.

> ⚠️ Открытие детального диалога по клику через preview-харнесс проверить не удалось (синтетические клики не доходят до делегированных обработчиков Blazor Server — то же и на существующей `FeatureCard`). `FeatureHero` использует ровно тот же путь открытия диалога, что и рабочая карточка; всплытие с кнопки погашено `stopPropagation`. Рекомендуется ручной клик-тест на `/features` перед мержем.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
