### PR TITLE
feat: track per-request memory allocations in performance panel

### DIFF
--- a/src/Pet.Jira.Application/Common/Behaviors/PerformanceBehavior.cs
+++ b/src/Pet.Jira.Application/Common/Behaviors/PerformanceBehavior.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Pet.Jira.Application.Tracing;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,16 +35,23 @@ namespace Pet.Jira.Application.Common.Behaviors
             CancellationToken cancellationToken)
         {
             var startTimestamp = Stopwatch.GetTimestamp();
+            // Process-wide allocation counter: captures allocations on parallel worker
+            // threads too (e.g. Parallel.ForEachAsync over issues), unlike the per-thread
+            // counter. It measures allocation throughput, not retained memory, and is only
+            // representative when requests do not run concurrently.
+            var startAllocatedBytes = GC.GetTotalAllocatedBytes(precise: false);
 
             var response = await next();
 
             var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            var allocatedBytes = Math.Max(0,
+                GC.GetTotalAllocatedBytes(precise: false) - startAllocatedBytes);
 
             // Queries/commands are nested types (e.g. GetWorklogCollection.Query), so the
             // outer type gives a meaningful, collision-free category name.
             var requestName = typeof(TRequest).DeclaringType?.Name ?? typeof(TRequest).Name;
 
-            _stats.Record(requestName, elapsed);
+            _stats.Record(requestName, elapsed, allocatedBytes);
 
             if (elapsed.TotalMilliseconds > SlowRequestThresholdMs)
             {

--- a/src/Pet.Jira.Application/Tracing/IPerformanceStatsCollector.cs
+++ b/src/Pet.Jira.Application/Tracing/IPerformanceStatsCollector.cs
@@ -4,12 +4,13 @@ using System.Collections.Generic;
 namespace Pet.Jira.Application.Tracing
 {
     /// <summary>
-    /// Collects aggregated timing statistics (count / sum / min / max / average) per category.
-    /// Registered as a singleton so the dev debug panel can read process-wide measures.
+    /// Collects aggregated timing and allocation statistics (count / sum / min / max /
+    /// average) per category. Registered as a singleton so the dev debug panel can read
+    /// process-wide measures.
     /// </summary>
     public interface IPerformanceStatsCollector
     {
-        void Record(string category, TimeSpan elapsed);
+        void Record(string category, TimeSpan elapsed, long allocatedBytes);
 
         IReadOnlyCollection<Measure> Measures { get; }
 

--- a/src/Pet.Jira.Application/Tracing/Measure.cs
+++ b/src/Pet.Jira.Application/Tracing/Measure.cs
@@ -13,6 +13,9 @@ namespace Pet.Jira.Application.Tracing
             Max = TimeSpan.Zero;
             Min = TimeSpan.MaxValue;
             Count = 0;
+            AllocatedSum = 0;
+            AllocatedMax = 0;
+            AllocatedMin = long.MaxValue;
 
             _syncRoot = new object();
         }
@@ -25,7 +28,14 @@ namespace Pet.Jira.Application.Tracing
 
         public TimeSpan Average => Count == 0 ? TimeSpan.Zero : new(Sum.Ticks / Count);
 
-        public void Update(TimeSpan elapsed)
+        /// <summary>Total bytes allocated across all recorded calls (GC allocation throughput, not retained memory).</summary>
+        public long AllocatedSum { get; private set; }
+        public long AllocatedMax { get; private set; }
+        public long AllocatedMin { get; private set; }
+
+        public long AllocatedAverage => Count == 0 ? 0 : AllocatedSum / Count;
+
+        public void Update(TimeSpan elapsed, long allocatedBytes)
         {
             lock (_syncRoot)
             {
@@ -41,6 +51,18 @@ namespace Pet.Jira.Application.Tracing
                 if (elapsed < Min)
                 {
                     Min = elapsed;
+                }
+
+                AllocatedSum += allocatedBytes;
+
+                if (allocatedBytes > AllocatedMax)
+                {
+                    AllocatedMax = allocatedBytes;
+                }
+
+                if (allocatedBytes < AllocatedMin)
+                {
+                    AllocatedMin = allocatedBytes;
                 }
             }
         }

--- a/src/Pet.Jira.Application/Tracing/PerformanceStatsCollector.cs
+++ b/src/Pet.Jira.Application/Tracing/PerformanceStatsCollector.cs
@@ -10,9 +10,9 @@ namespace Pet.Jira.Application.Tracing
         private readonly ConcurrentDictionary<string, Measure> _measures =
             new ConcurrentDictionary<string, Measure>(StringComparer.InvariantCultureIgnoreCase);
 
-        public void Record(string category, TimeSpan elapsed)
+        public void Record(string category, TimeSpan elapsed, long allocatedBytes)
         {
-            _measures.GetOrAdd(category, c => new Measure(c)).Update(elapsed);
+            _measures.GetOrAdd(category, c => new Measure(c)).Update(elapsed, allocatedBytes);
         }
 
         public IReadOnlyCollection<Measure> Measures => _measures.Values.ToArray();

--- a/src/Pet.Jira.Web/Components/Performance/Performance.razor.cs
+++ b/src/Pet.Jira.Web/Components/Performance/Performance.razor.cs
@@ -33,18 +33,35 @@ namespace Pet.Jira.Web.Components.Performance
             }
 
             var stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine("| Category | Count | Sum, ms | Min, ms | Max, ms | Average, ms |");
-            stringBuilder.AppendLine("|---|--:|--:|--:|--:|--:|");
+            stringBuilder.AppendLine("| Category | Count | Sum, ms | Min, ms | Max, ms | Average, ms | Alloc avg | Alloc max | Alloc sum |");
+            stringBuilder.AppendLine("|---|--:|--:|--:|--:|--:|--:|--:|--:|");
             foreach (var measure in measures)
             {
                 stringBuilder.AppendLine(
-                    $"| {measure.Category} | {measure.Count} | {Milliseconds(measure.Sum)} | {Milliseconds(measure.Min)} | {Milliseconds(measure.Max)} | {Milliseconds(measure.Average)} |");
+                    $"| {measure.Category} | {measure.Count} | {Milliseconds(measure.Sum)} | {Milliseconds(measure.Min)} | {Milliseconds(measure.Max)} | {Milliseconds(measure.Average)} | {Bytes(measure.AllocatedAverage)} | {Bytes(measure.AllocatedMax)} | {Bytes(measure.AllocatedSum)} |");
             }
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("_Alloc — объём аллокаций (произведённый «мусор» GC), а не удержанная память. Метрика процессная: корректна при отсутствии параллельных запросов._");
 
             return stringBuilder.ToString();
         }
 
         private static string Milliseconds(TimeSpan value) =>
             value.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture);
+
+        private static string Bytes(long value)
+        {
+            string[] units = { "B", "KB", "MB", "GB", "TB" };
+            double size = value;
+            var unit = 0;
+            while (size >= 1024 && unit < units.Length - 1)
+            {
+                size /= 1024;
+                unit++;
+            }
+
+            return $"{size.ToString(unit == 0 ? "F0" : "F1", CultureInfo.InvariantCulture)} {units[unit]}";
+        }
     }
 }


### PR DESCRIPTION
## Что

Добавляет учёт аллокаций памяти по каждому MediatR-запросу в дев-панель `/performance`, рядом с таймингами.

## Как

- В `PerformanceBehavior` снимается `GC.GetTotalAllocatedBytes(precise: false)` до/после `next()`, дельта агрегируется в `Measure` (sum/min/max/avg байт).
- Панель `/performance` получает колонки **Alloc avg / max / sum** с человекочитаемым форматом (B/KB/MB…).

## Ограничения (указаны сноской в панели)

- Метрика — **объём аллокаций** (произведённый GC-мусор), а не удержанная память.
- Счётчик **процессный**: ловит аллокации параллельных воркеров (`Parallel.ForEachAsync`), но корректен только при отсутствии параллельных запросов.
- Меряются только запросы через MediatR (как и тайминги сейчас).

## Мотивация

Позволяет количественно оценивать память в разрезе метода — в частности, сравнить выигрыш по аллокациям для оптимизации получения ворклогов (#245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
