### PR TITLE
feat: redesign empty-state / 404 stub as an animated scene

### DIFF
--- a/src/Pet.Jira.Web/Components/Common/ErrorContainer.razor
+++ b/src/Pet.Jira.Web/Components/Common/ErrorContainer.razor
@@ -1,5 +1,5 @@
 ﻿<MudContainer>
-    <Stub Message="SORRY ~ PAGE NOT FOUND"/>
+    <Stub Message="SORRY ~ PAGE NOT FOUND" FillViewport="true" />
 </MudContainer>
 
 @code {

--- a/src/Pet.Jira.Web/Components/Common/Stub.razor
+++ b/src/Pet.Jira.Web/Components/Common/Stub.razor
@@ -1,20 +1,272 @@
-﻿<style>
-    .pet-stub-logo {
-        width: 256px;
-        height: 256px;
+<style>
+    /* ── Stub / empty-state / 404 — "signal lost in space" ──────────────── */
+    .stub {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 46px;
+        width: 100%;
+        flex: 1 1 auto;
+        min-height: clamp(360px, 62vh, 640px);
+        padding: 48px 24px;
+        overflow: hidden;
+        isolation: isolate;
+        text-align: center;
+        --stub-accent: var(--mud-palette-primary);
+        --stub-accent-rgb: var(--mud-palette-primary-rgb);
     }
 
-    @@media (max-width:1000px) {
-        .pet-stub-logo {
-            width: 200px;
-            height: 200px;
+    /* Faded blueprint grid, masked to a soft circle around the centre. */
+    .stub::before {
+        content: "";
+        position: absolute;
+        inset: -20%;
+        z-index: -2;
+        background-image:
+            linear-gradient(to right, rgba(var(--stub-accent-rgb), .11) 1px, transparent 1px),
+            linear-gradient(to bottom, rgba(var(--stub-accent-rgb), .11) 1px, transparent 1px);
+        background-size: 42px 42px;
+        -webkit-mask-image: radial-gradient(circle at 50% 42%, #000 0%, transparent 62%);
+        mask-image: radial-gradient(circle at 50% 42%, #000 0%, transparent 62%);
+        animation: stub-drift 26s linear infinite;
+    }
+
+    /* Ambient colour wash behind the whole scene. */
+    .stub::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: -3;
+        background:
+            radial-gradient(60% 55% at 50% 40%, rgba(var(--stub-accent-rgb), .16), transparent 70%),
+            radial-gradient(90% 90% at 50% 120%, rgba(var(--stub-accent-rgb), .08), transparent 60%);
+    }
+
+    /* ── Stage: the orbiting system around the logo ─────────────────────── */
+    .stub__stage {
+        position: relative;
+        display: grid;
+        place-items: center;
+        width: clamp(240px, 34vw, 340px);
+        height: clamp(240px, 34vw, 340px);
+        animation: stub-pop .9s cubic-bezier(.2,.8,.2,1) both;
+    }
+
+    /* Pulsing halo directly behind the robot. */
+    .stub__glow {
+        position: absolute;
+        width: 62%;
+        height: 62%;
+        border-radius: 50%;
+        background: radial-gradient(circle, rgba(var(--stub-accent-rgb), .55), transparent 68%);
+        filter: blur(26px);
+        animation: stub-breathe 4.5s ease-in-out infinite;
+    }
+
+    /* Radar sweep — a faint rotating wedge scanning the void. */
+    .stub__radar {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: conic-gradient(from 0deg, rgba(var(--stub-accent-rgb), .22), transparent 22%, transparent 100%);
+        -webkit-mask-image: radial-gradient(circle, transparent 30%, #000 31%, #000 100%);
+        mask-image: radial-gradient(circle, transparent 30%, #000 31%, #000 100%);
+        opacity: .5;
+        animation: stub-spin 7s linear infinite;
+    }
+
+    .stub__orbit {
+        position: absolute;
+        border: 1px dashed rgba(var(--stub-accent-rgb), .38);
+        border-radius: 50%;
+    }
+    .stub__orbit--outer {
+        width: 100%;
+        height: 100%;
+        animation: stub-spin 22s linear infinite;
+    }
+    .stub__orbit--inner {
+        width: 74%;
+        height: 74%;
+        border-style: dotted;
+        border-color: rgba(var(--stub-accent-rgb), .28);
+        animation: stub-spin 15s linear infinite reverse;
+    }
+
+    /* Satellite riding the outer orbit. */
+    .stub__satellite {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        animation: stub-spin 22s linear infinite;
+    }
+    .stub__satellite::before {
+        content: "";
+        position: absolute;
+        top: -6px;
+        left: calc(50% - 6px);
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--stub-accent);
+        box-shadow: 0 0 14px 2px rgba(var(--stub-accent-rgb), .9);
+    }
+
+    /* The robot logo itself, floating. */
+    .stub__logo {
+        position: relative;
+        z-index: 1;
+        width: clamp(150px, 20vw, 208px) !important;
+        height: clamp(150px, 20vw, 208px) !important;
+        filter: drop-shadow(0 18px 30px rgba(var(--stub-accent-rgb), .45));
+        animation: stub-float 6s ease-in-out infinite;
+    }
+
+    /* Twinkling starfield. */
+    .stub__star {
+        position: absolute;
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: var(--stub-accent);
+        opacity: .0;
+        z-index: -1;
+        animation: stub-twinkle 3.2s ease-in-out infinite;
+    }
+    .stub__star--1 { top: 12%;  left: 20%; animation-delay: .0s;  }
+    .stub__star--2 { top: 24%;  left: 82%; animation-delay: .6s;  width: 3px; height: 3px; }
+    .stub__star--3 { top: 68%;  left: 14%; animation-delay: 1.1s; width: 5px; height: 5px; }
+    .stub__star--4 { top: 78%;  left: 78%; animation-delay: 1.7s; }
+    .stub__star--5 { top: 44%;  left: 6%;  animation-delay: 2.3s; width: 3px; height: 3px; }
+    .stub__star--6 { top: 8%;   left: 56%; animation-delay: 2.9s; width: 3px; height: 3px; }
+    .stub__star--7 { top: 88%;  left: 44%; animation-delay: .9s;  }
+
+    /* ── Message ────────────────────────────────────────────────────────── */
+    .stub__message {
+        position: relative;
+        max-width: 34ch;
+        font-weight: 500;
+        letter-spacing: .01em;
+        line-height: 1.5;
+        animation: stub-rise .8s .2s cubic-bezier(.2,.8,.2,1) both;
+    }
+    .stub__message::after {
+        content: "";
+        display: inline-block;
+        width: .62em;
+        height: 1.05em;
+        margin-left: .18em;
+        vertical-align: -.16em;
+        background: var(--stub-accent);
+        animation: stub-caret 1.1s steps(1) infinite;
+    }
+    /* Decorative meridians flanking the message. */
+    .stub__rule {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        margin-top: 18px;
+        animation: stub-rise .8s .35s cubic-bezier(.2,.8,.2,1) both;
+    }
+    .stub__rule span {
+        display: block;
+        height: 1px;
+        width: 42px;
+        background: linear-gradient(90deg, transparent, rgba(var(--stub-accent-rgb), .7));
+    }
+    .stub__rule span:last-child { background: linear-gradient(90deg, rgba(var(--stub-accent-rgb), .7), transparent); }
+    .stub__rule i {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--stub-accent);
+        box-shadow: 0 0 10px rgba(var(--stub-accent-rgb), .9);
+        animation: stub-breathe 2.2s ease-in-out infinite;
+    }
+
+    /* ── Keyframes ──────────────────────────────────────────────────────── */
+    @@keyframes stub-float {
+        0%, 100% { transform: translateY(-8px) rotate(-1.5deg); }
+        50%      { transform: translateY(10px) rotate(1.5deg); }
+    }
+    @@keyframes stub-breathe {
+        0%, 100% { transform: scale(1);    opacity: .8; }
+        50%      { transform: scale(1.12); opacity: 1; }
+    }
+    @@keyframes stub-spin {
+        to { transform: rotate(360deg); }
+    }
+    @@keyframes stub-twinkle {
+        0%, 100% { opacity: 0;   transform: scale(.5); }
+        50%      { opacity: .85; transform: scale(1); }
+    }
+    @@keyframes stub-drift {
+        to { background-position: 42px 42px; }
+    }
+    @@keyframes stub-caret {
+        0%, 50%   { opacity: 1; }
+        50.01%, 100% { opacity: 0; }
+    }
+    @@keyframes stub-pop {
+        0%   { opacity: 0; transform: scale(.82); }
+        100% { opacity: 1; transform: scale(1); }
+    }
+    @@keyframes stub-rise {
+        0%   { opacity: 0; transform: translateY(16px); }
+        100% { opacity: 1; transform: translateY(0); }
+    }
+
+    @@media (max-width: 1000px) {
+        .stub { gap: 34px; }
+    }
+
+    /* Web (tablet & up): standalone stubs (e.g. 404) fill the whole content area below the
+       app bar. Empty states beneath a page header keep the content-based height above so they
+       never push past the bottom of the screen. */
+    @@media (min-width: 600px) {
+        .stub--fill {
+            /* content box is 100vh with ~7/8 app-bar padding-top; wrappers add ~32px. */
+            min-height: calc(100vh - var(--mud-appbar-height, 64px) - 32px);
         }
+    }
+
+    @@media (prefers-reduced-motion: reduce) {
+        .stub *, .stub::before {
+            animation: none !important;
+        }
+        .stub__star { opacity: .7; }
+        .stub__message::after { animation: none; opacity: 1; }
     }
 </style>
 
-<MudContainer Class="pet-horizontal-center pet-vertical-center">
-    <MudIcon Icon="@Icon" ViewBox="@ViewBox" Class="pet-stub-logo" />
-    <MudText Typo="Typo.body2" Color="@Color" Class="mt-4">@Message</MudText>
-</MudContainer>
+<div class="stub @(FillViewport ? "stub--fill" : null)">
+    <span class="stub__star stub__star--1"></span>
+    <span class="stub__star stub__star--2"></span>
+    <span class="stub__star stub__star--3"></span>
+    <span class="stub__star stub__star--4"></span>
+    <span class="stub__star stub__star--5"></span>
+    <span class="stub__star stub__star--6"></span>
+    <span class="stub__star stub__star--7"></span>
+
+    <div class="stub__stage">
+        <div class="stub__glow"></div>
+        <div class="stub__radar"></div>
+        <div class="stub__orbit stub__orbit--outer"></div>
+        <div class="stub__orbit stub__orbit--inner"></div>
+        <div class="stub__satellite"></div>
+        <MudIcon Icon="@Icon" ViewBox="@ViewBox" Class="stub__logo" />
+    </div>
+
+    <div>
+        <MudText Typo="Typo.h6" Color="@Color" Class="stub__message">@Message</MudText>
+        <div class="stub__rule">
+            <span></span><i></i><span></span>
+        </div>
+    </div>
+</div>
 
 @code {}

--- a/src/Pet.Jira.Web/Components/Common/Stub.razor.cs
+++ b/src/Pet.Jira.Web/Components/Common/Stub.razor.cs
@@ -10,5 +10,12 @@ namespace Pet.Jira.Web.Components.Common
         [Parameter] public string Icon { get; set; } = WebConstants.Icons.Favicon;
         [Parameter] public string Message { get; set; }
         [Parameter] public string ViewBox { get; set; } = "0 0 260 260";
+
+        /// <summary>
+        /// When <c>true</c>, the stub stretches to fill the whole viewport height below the app bar
+        /// (used for standalone screens like 404). Leave <c>false</c> for empty states rendered
+        /// beneath a page header, so the stub sizes to its content and never overflows the screen.
+        /// </summary>
+        [Parameter] public bool FillViewport { get; set; }
     }
 }


### PR DESCRIPTION
## Что делает

Редизайн shared-компонента **Stub** — того, что рендерит пустые состояния (Features, Releases, worklog-виджет) и страницу **404**.

Вместо статичного логотипа + текста теперь анимированная сцена «потерянный сигнал в космосе»: логотип парит с дышащим ореолом, вокруг вращаются пунктирные орбитальные кольца и спутник, радар-сектор сканирует пустоту, мерцают звёзды, а сообщение завершается мигающим курсором.

## Изменения

- **Анимация только на CSS**, self-contained внутри компонента; цвета берутся из палитры MudBlazor (`--mud-palette-primary` / `-rgb`), поэтому сцена автоматически адаптируется к светлой/тёмной теме.
- **Доступность:** при `prefers-reduced-motion: reduce` все анимации отключаются, звёзды и курсор остаются статично видимыми.
- **Новый параметр `FillViewport`:**
  - `true` (404) — stub занимает всю высоту контент-области под аппбаром;
  - `false` (по умолчанию, пустые состояния под заголовком секции) — высота по содержимому, чтобы stub не уходил за нижнюю границу экрана.
- Публичный API (`Message`, `Icon`, `Color`, `ViewBox`) не изменён — все места использования продолжают работать.

## Проверка (окно 961×918)

| Контекст | `FillViewport` | Высота | Вертикальный скролл |
|---|---|---|---|
| 404 | `true` | 822px (полная) | нет |
| Пустое состояние под заголовком | `false` | 569px (по контенту) | нет |

Проверено в светлой и тёмной теме; `dotnet build` — 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
