### PR TITLE
perf: optimize Jira event retrieval (#258)

### DIFF
--- a/src/Pet.Jira.Application/Worklogs/IWorklogDataSource.cs
+++ b/src/Pet.Jira.Application/Worklogs/IWorklogDataSource.cs
@@ -1,4 +1,4 @@
-﻿using Pet.Jira.Application.Worklogs.Queries;
+using Pet.Jira.Application.Worklogs.Queries;
 using Pet.Jira.Domain.Models.Worklogs;
 using System.Collections.Generic;
 using System.Threading;
@@ -12,8 +12,16 @@ namespace Pet.Jira.Application.Worklogs
             GetIssueWorklogs.Query query,
             CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<IWorklog>> GetRawIssueWorklogsAsync(
-            GetRawIssueWorklogs.Query query,
+        Task<IEnumerable<IWorklog>> GetAssigneeRawIssueWorklogsAsync(
+            GetAssigneeJiraEvents.Query query,
+            CancellationToken cancellationToken = default);
+
+        Task<IEnumerable<IWorklog>> GetTesterRawIssueWorklogsAsync(
+            GetTesterJiraEvents.Query query,
+            CancellationToken cancellationToken = default);
+
+        Task<IEnumerable<IWorklog>> GetCommentRawIssueWorklogsAsync(
+            GetCommentJiraEvents.Query query,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetAssigneeJiraEvents.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetAssigneeJiraEvents.cs
@@ -18,7 +18,6 @@ namespace Pet.Jira.Application.Worklogs.Queries
         {
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }
-            public string IssueStatusId { get; set; }
         }
 
         public class QueryHandler : IRequestHandler<Query, IEnumerable<IWorklog>>

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetAssigneeJiraEvents.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetAssigneeJiraEvents.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using Pet.Jira.Domain.Models.Worklogs;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Worklogs.Queries
+{
+    /// <summary>
+    /// Estimated worklogs derived from the "In Progress" status changes of issues
+    /// assigned to the current user. Split out from the former GetRawIssueWorklogs so
+    /// its performance can be measured independently. See issue #258.
+    /// </summary>
+    public class GetAssigneeJiraEvents
+    {
+        public class Query : IRequest<IEnumerable<IWorklog>>
+        {
+            public DateTime StartDate { get; set; }
+            public DateTime EndDate { get; set; }
+            public string IssueStatusId { get; set; }
+        }
+
+        public class QueryHandler : IRequestHandler<Query, IEnumerable<IWorklog>>
+        {
+            private readonly IWorklogDataSource _worklogDataSource;
+
+            public QueryHandler(IWorklogDataSource worklogDataSource)
+            {
+                _worklogDataSource = worklogDataSource;
+            }
+
+            public Task<IEnumerable<IWorklog>> Handle(
+                Query request,
+                CancellationToken cancellationToken)
+                => _worklogDataSource.GetAssigneeRawIssueWorklogsAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetCommentJiraEvents.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetCommentJiraEvents.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using Pet.Jira.Domain.Models.Worklogs;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pet.Jira.Application.Worklogs.Queries
+{
+    /// <summary>
+    /// Estimated worklogs derived from the current user's comments on issues they watch
+    /// but are not assigned to. Split out from the former GetRawIssueWorklogs so its
+    /// performance can be measured independently. See issue #258.
+    /// </summary>
+    public class GetCommentJiraEvents
+    {
+        public class Query : IRequest<IEnumerable<IWorklog>>
+        {
+            public DateTime StartDate { get; set; }
+            public DateTime EndDate { get; set; }
+            public TimeSpan CommentWorklogTime { get; set; }
+        }
+
+        public class QueryHandler : IRequestHandler<Query, IEnumerable<IWorklog>>
+        {
+            private readonly IWorklogDataSource _worklogDataSource;
+
+            public QueryHandler(IWorklogDataSource worklogDataSource)
+            {
+                _worklogDataSource = worklogDataSource;
+            }
+
+            public Task<IEnumerable<IWorklog>> Handle(
+                Query request,
+                CancellationToken cancellationToken)
+                => _worklogDataSource.GetCommentRawIssueWorklogsAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetTesterJiraEvents.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetTesterJiraEvents.cs
@@ -7,14 +7,18 @@ using System.Threading.Tasks;
 
 namespace Pet.Jira.Application.Worklogs.Queries
 {
-    public class GetRawIssueWorklogs
+    /// <summary>
+    /// Estimated worklogs derived from the "In Testing" status changes of issues where
+    /// the current user is the tester. Split out from the former GetRawIssueWorklogs so
+    /// its performance can be measured independently. See issue #258.
+    /// </summary>
+    public class GetTesterJiraEvents
     {
         public class Query : IRequest<IEnumerable<IWorklog>>
         {
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }
             public string IssueStatusId { get; set; }
-            public TimeSpan CommentWorklogTime { get; set; }
         }
 
         public class QueryHandler : IRequestHandler<Query, IEnumerable<IWorklog>>
@@ -29,7 +33,7 @@ namespace Pet.Jira.Application.Worklogs.Queries
             public Task<IEnumerable<IWorklog>> Handle(
                 Query request,
                 CancellationToken cancellationToken)
-                => _worklogDataSource.GetRawIssueWorklogsAsync(request, cancellationToken);
+                => _worklogDataSource.GetTesterRawIssueWorklogsAsync(request, cancellationToken);
         }
     }
 }

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetTesterJiraEvents.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetTesterJiraEvents.cs
@@ -18,7 +18,6 @@ namespace Pet.Jira.Application.Worklogs.Queries
         {
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }
-            public string IssueStatusId { get; set; }
         }
 
         public class QueryHandler : IRequestHandler<Query, IEnumerable<IWorklog>>

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
@@ -56,24 +56,27 @@ namespace Pet.Jira.Application.Worklogs.Queries
             private async Task<IEnumerable<WorkingDay>> CalculateWorklogCollection(Query query,
                 CancellationToken cancellationToken)
             {
-                // Sent sequentially so PerformanceBehavior can measure each Jira-events
-                // request (assignee/tester/comment) in isolation — its allocation stats
-                // are only representative for non-concurrent requests. See issue #258.
-                var assigneeWorklogs = await _mediator.Send(
+                // Kick off the independent data fetches concurrently to cut wall-clock.
+                // Safe against the scoped, non-thread-safe ApplicationDbContext: only the
+                // calendar path touches it, and it runs as a single task, so there is no
+                // concurrent DbContext access; the Jira queries use transient services with
+                // no shared state. Trade-off: PerformanceBehavior's per-request allocation
+                // stats are not representative while these run concurrently. See issue #258.
+                var assigneeTask = _mediator.Send(
                     new GetAssigneeJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
                         EndDate = query.EndDate
                     }, cancellationToken);
 
-                var testerWorklogs = await _mediator.Send(
+                var testerTask = _mediator.Send(
                     new GetTesterJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
                         EndDate = query.EndDate
                     }, cancellationToken);
 
-                var commentWorklogs = await _mediator.Send(
+                var commentTask = _mediator.Send(
                     new GetCommentJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
@@ -81,18 +84,25 @@ namespace Pet.Jira.Application.Worklogs.Queries
                         CommentWorklogTime = query.CommentWorklogTime
                     }, cancellationToken);
 
-                var rawIssueWorklogs = assigneeWorklogs
-                    .Concat(testerWorklogs)
-                    .Concat(commentWorklogs);
-
-                var issueWorklogs = await _mediator.Send(
+                var issueWorklogsTask = _mediator.Send(
                     new GetIssueWorklogs.Query()
                     {
                         StartDate = query.StartDate,
                         EndDate = query.EndDate
                     }, cancellationToken);
 
-                var (calendarWorklogs, blockedEventsByDay) = await GetCalendarWorklogsAsync(query, cancellationToken);
+                var calendarTask = GetCalendarWorklogsAsync(query, cancellationToken);
+
+                await Task.WhenAll(
+                    assigneeTask, testerTask, commentTask, issueWorklogsTask, calendarTask);
+
+                var rawIssueWorklogs = (await assigneeTask)
+                    .Concat(await testerTask)
+                    .Concat(await commentTask);
+
+                var issueWorklogs = await issueWorklogsTask;
+
+                var (calendarWorklogs, blockedEventsByDay) = await calendarTask;
 
                 var allRawWorklogs = rawIssueWorklogs.Concat(calendarWorklogs);
 

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
@@ -63,16 +63,14 @@ namespace Pet.Jira.Application.Worklogs.Queries
                     new GetAssigneeJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
-                        EndDate = query.EndDate,
-                        IssueStatusId = query.IssueStatusId
+                        EndDate = query.EndDate
                     }, cancellationToken);
 
                 var testerWorklogs = await _mediator.Send(
                     new GetTesterJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
-                        EndDate = query.EndDate,
-                        IssueStatusId = query.IssueStatusId
+                        EndDate = query.EndDate
                     }, cancellationToken);
 
                 var commentWorklogs = await _mediator.Send(

--- a/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
+++ b/src/Pet.Jira.Application/Worklogs/Queries/GetWorklogCollection.cs
@@ -56,14 +56,36 @@ namespace Pet.Jira.Application.Worklogs.Queries
             private async Task<IEnumerable<WorkingDay>> CalculateWorklogCollection(Query query,
                 CancellationToken cancellationToken)
             {
-                var rawIssueWorklogs = await _mediator.Send(
-                    new GetRawIssueWorklogs.Query()
+                // Sent sequentially so PerformanceBehavior can measure each Jira-events
+                // request (assignee/tester/comment) in isolation — its allocation stats
+                // are only representative for non-concurrent requests. See issue #258.
+                var assigneeWorklogs = await _mediator.Send(
+                    new GetAssigneeJiraEvents.Query()
                     {
                         StartDate = query.StartDate,
                         EndDate = query.EndDate,
-                        IssueStatusId = query.IssueStatusId,
+                        IssueStatusId = query.IssueStatusId
+                    }, cancellationToken);
+
+                var testerWorklogs = await _mediator.Send(
+                    new GetTesterJiraEvents.Query()
+                    {
+                        StartDate = query.StartDate,
+                        EndDate = query.EndDate,
+                        IssueStatusId = query.IssueStatusId
+                    }, cancellationToken);
+
+                var commentWorklogs = await _mediator.Send(
+                    new GetCommentJiraEvents.Query()
+                    {
+                        StartDate = query.StartDate,
+                        EndDate = query.EndDate,
                         CommentWorklogTime = query.CommentWorklogTime
                     }, cancellationToken);
+
+                var rawIssueWorklogs = assigneeWorklogs
+                    .Concat(testerWorklogs)
+                    .Concat(commentWorklogs);
 
                 var issueWorklogs = await _mediator.Send(
                     new GetIssueWorklogs.Query()

--- a/src/Pet.Jira.Infrastructure/Jira/Dto/IssueChangeLogItemDto.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/Dto/IssueChangeLogItemDto.cs
@@ -1,9 +1,11 @@
-﻿namespace Pet.Jira.Infrastructure.Jira.Dto
+namespace Pet.Jira.Infrastructure.Jira.Dto
 {
     public class IssueChangeLogItemDto
     {
         public string FromId { get; set; }
         public string ToId { get; set; }
+        public string FromValue { get; set; }
+        public string ToValue { get; set; }
         public IssueChangeLogDto ChangeLog { get; set; }
         public string Author { get; set; }
     }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraConstants.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraConstants.cs
@@ -10,7 +10,9 @@ namespace Pet.Jira.Infrastructure.Jira
         public static class Status
         {
             public const string FieldName = "status";
-            public static IssueStatus Default => new() { Id = "3", Name = "In Progress" };
+            public static IssueStatus InProgress => new() { Id = "3", Name = "In Progress" };
+            public static IssueStatus InTesting => new() { Id = "10116", Name = "In Testing" };
+            public static IssueStatus Default => InProgress;
         }
     }
 }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraExtensions.cs
@@ -18,7 +18,7 @@ namespace Pet.Jira.Infrastructure.Jira
 		}
 
         public static IEnumerable<T> ConvertTo<T>(this IList<IssueChangeLogItemDto> issueChangeLogItems,
-            string issueStatusId,
+            string statusName,
             ITimeProvider timeProvider,
             TimeZoneInfo timeZoneInfo,
 			WorklogSource worklogSource)
@@ -29,7 +29,7 @@ namespace Pet.Jira.Infrastructure.Jira
             {
                 var item = issueChangeLogItems[i];
                 // 1. Первый элемент сразу выходит из прогресса. Значит это завершающий
-                if (item.FromId == issueStatusId)
+                if (item.FromValue == statusName)
                 {
                     yield return new T()
                     {

--- a/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
@@ -244,6 +244,8 @@ namespace Pet.Jira.Infrastructure.Jira
                         {
                             FromId = issueChangeLogItem.FromId,
                             ToId = issueChangeLogItem.ToId,
+                            FromValue = issueChangeLogItem.FromValue,
+                            ToValue = issueChangeLogItem.ToValue,
                             ChangeLog = IssueChangeLogDto.Create(issueChangeLog, issue),
                             Author = issueChangeLog.Author.Username
                         });

--- a/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraService.cs
@@ -388,16 +388,17 @@ namespace Pet.Jira.Infrastructure.Jira
             Func<Comment, bool> filter = null,
             CancellationToken cancellationToken = default)
         {
-            var result = new List<IssueCommentDto> { };
-            foreach (var issue in issues)
+            var result = new ConcurrentBag<IssueCommentDto> { };
+            await Parallel.ForEachAsync(issues, DefaultParallelOptions, async (issue, cancellationToken) =>
             {
                 var options = new CommentQueryOptions();
                 var comments = await _jiraClient.Issues.GetCommentsAsync(issue.Key, options, cancellationToken);
                 comments = comments.WhereIfNotNull(filter);
-
-                result.AddRange(comments.Select(comment =>
-                    IssueCommentDto.Create(comment, issue)));
-            }
+                foreach (var comment in comments)
+                {
+                    result.Add(IssueCommentDto.Create(comment, issue));
+                }
+            });
 
             return result;
         }

--- a/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
@@ -72,13 +72,14 @@ namespace Pet.Jira.Infrastructure.Jira
 		}
 
 		/// <summary>
-		/// Get raw issue worklogs
+		/// Get estimated worklogs from the "In Progress" status changes of issues
+		/// assigned to the current user. See issue #258.
 		/// </summary>
 		/// <param name="query"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task<IEnumerable<IWorklog>> GetRawIssueWorklogsAsync(
-			GetRawIssueWorklogs.Query query,
+		public async Task<IEnumerable<IWorklog>> GetAssigneeRawIssueWorklogsAsync(
+			GetAssigneeJiraEvents.Query query,
 			CancellationToken cancellationToken = default)
 		{
 			var issueQuery = _queryFactory.Create()
@@ -119,21 +120,18 @@ namespace Pet.Jira.Infrastructure.Jira
 				result.AddRange(rawIssueWorklogs);
 			}
 
-			var commentWorklogs = await GetCommentRawIssueWorklogsAsync(query, cancellationToken);
-			var testerWorklogs = await GetTesterRawIssueWorklogsAsync(query, cancellationToken);
-			result.AddRange(commentWorklogs);
-			result.AddRange(testerWorklogs);
 			return result.Where(item => item.Author == userProfile.Username);
 		}
 
 		/// <summary>
-		/// Get raw issue worklogs
+		/// Get estimated worklogs from the current user's comments on watched issues
+		/// they are not assigned to. See issue #258.
 		/// </summary>
 		/// <param name="query"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task<IEnumerable<RawIssueWorklog>> GetCommentRawIssueWorklogsAsync(
-			GetRawIssueWorklogs.Query query,
+		public async Task<IEnumerable<IWorklog>> GetCommentRawIssueWorklogsAsync(
+			GetCommentJiraEvents.Query query,
 			CancellationToken cancellationToken = default)
 		{
 			var issueQuery = _queryFactory.Create()
@@ -175,13 +173,14 @@ namespace Pet.Jira.Infrastructure.Jira
 		}
 
 		/// <summary>
-		/// Get raw issue worklogs
+		/// Get estimated worklogs from the "In Testing" status changes of issues where
+		/// the current user is the tester. See issue #258.
 		/// </summary>
 		/// <param name="query"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task<IEnumerable<RawIssueWorklog>> GetTesterRawIssueWorklogsAsync(
-			GetRawIssueWorklogs.Query query,
+		public async Task<IEnumerable<IWorklog>> GetTesterRawIssueWorklogsAsync(
+			GetTesterJiraEvents.Query query,
 			CancellationToken cancellationToken = default)
 		{
 			var issueQuery = _queryFactory.Create()

--- a/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
@@ -51,12 +51,6 @@ namespace Pet.Jira.Infrastructure.Jira
 				AdditionalFields = { "summary" }
 			};
 
-		/// <summary>
-		/// Get issue worklogs
-		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task<IEnumerable<IWorklog>> GetIssueWorklogsAsync(
 			GetIssueWorklogs.Query query,
 			CancellationToken cancellationToken = default)
@@ -89,9 +83,6 @@ namespace Pet.Jira.Infrastructure.Jira
 		/// Get estimated worklogs from the "In Progress" status changes of issues
 		/// assigned to the current user. See issue #258.
 		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task<IEnumerable<IWorklog>> GetAssigneeRawIssueWorklogsAsync(
 			GetAssigneeJiraEvents.Query query,
 			CancellationToken cancellationToken = default)
@@ -140,9 +131,6 @@ namespace Pet.Jira.Infrastructure.Jira
 		/// Get estimated worklogs from the current user's comments on watched issues
 		/// they are not assigned to. See issue #258.
 		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task<IEnumerable<IWorklog>> GetCommentRawIssueWorklogsAsync(
 			GetCommentJiraEvents.Query query,
 			CancellationToken cancellationToken = default)
@@ -186,9 +174,6 @@ namespace Pet.Jira.Infrastructure.Jira
 		/// Get estimated worklogs from the "In Testing" status changes of issues where
 		/// the current user is the tester. See issue #258.
 		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task<IEnumerable<IWorklog>> GetTesterRawIssueWorklogsAsync(
 			GetTesterJiraEvents.Query query,
 			CancellationToken cancellationToken = default)

--- a/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
@@ -38,6 +38,20 @@ namespace Pet.Jira.Infrastructure.Jira
 		}
 
 		/// <summary>
+		/// Search options for the Jira-event queries. The events only need the issue
+		/// summary for display; the heavy work is the per-issue changelog/comment fetch
+		/// that follows. Restricting the search to the summary field keeps the initial
+		/// JQL response small instead of pulling every navigable field. See issue #258.
+		/// </summary>
+		private static IssueSearchOptions CreateEventSearchOptions(string jql) =>
+			new(jql)
+			{
+				MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest,
+				FetchBasicFields = false,
+				AdditionalFields = { "summary" }
+			};
+
+		/// <summary>
 		/// Get issue worklogs
 		/// </summary>
 		/// <param name="query"></param>
@@ -88,10 +102,7 @@ namespace Pet.Jira.Infrastructure.Jira
 				.WhereWas("status", "In Progress", query.StartDate, query.EndDate)
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
-			var issueSearchOptions = new IssueSearchOptions(issueQuery)
-			{
-				MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
-			};
+			var issueSearchOptions = CreateEventSearchOptions(issueQuery);
 
 			var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
 
@@ -140,10 +151,7 @@ namespace Pet.Jira.Infrastructure.Jira
 				.Where("assignee", JiraQueryComparisonType.NotEqual, JiraQueryMacros.CurrentUser)
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
-			var issueSearchOptions = new IssueSearchOptions(issueQuery)
-			{
-				MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
-			};
+			var issueSearchOptions = CreateEventSearchOptions(issueQuery);
 
 			var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
 
@@ -189,10 +197,7 @@ namespace Pet.Jira.Infrastructure.Jira
 				.Where("type", JiraQueryComparisonType.NotEqual, "Story")
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
-			var issueSearchOptions = new IssueSearchOptions(issueQuery)
-			{
-				MaxIssuesPerRequest = JiraConstants.DefaultMaxIssuesPerRequest
-			};
+			var issueSearchOptions = CreateEventSearchOptions(issueQuery);
 
 			var issues = await _jiraService.GetIssuesAsync(issueSearchOptions, cancellationToken);
 

--- a/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/JiraWorklogDataSource.cs
@@ -99,7 +99,7 @@ namespace Pet.Jira.Infrastructure.Jira
 			var issueQuery = _queryFactory.Create()
 				.Where("assignee", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
 				.Where("type", JiraQueryComparisonType.NotEqual, "Story")
-				.WhereWas("status", "In Progress", query.StartDate, query.EndDate)
+				.WhereWas("status", JiraConstants.Status.InProgress.Name, query.StartDate, query.EndDate)
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
 			var issueSearchOptions = CreateEventSearchOptions(issueQuery);
@@ -112,10 +112,12 @@ namespace Pet.Jira.Infrastructure.Jira
 			var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
 				changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
 
+			// Match the status by name, consistent with the JQL above — avoids depending
+			// on a hardcoded status id that varies between Jira instances. See issue #258.
 			var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
 				changeLogItem.FieldName == JiraConstants.Status.FieldName
-				&& (changeLogItem.ToId == query.IssueStatusId
-					|| changeLogItem.FromId == query.IssueStatusId));
+				&& (changeLogItem.ToValue == JiraConstants.Status.InProgress.Name
+					|| changeLogItem.FromValue == JiraConstants.Status.InProgress.Name));
 
 			var issueChangeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(issues, changeLogFilter, changeLogItemFilter, cancellationToken);
 
@@ -126,7 +128,7 @@ namespace Pet.Jira.Infrastructure.Jira
 					.Where(item => item.ChangeLog.Issue.Key == issue.Key)
 					.OrderBy(item => item.ChangeLog.CreatedDate)
 					.ToList()
-					.ConvertTo<RawIssueWorklog>(query.IssueStatusId, _timeProvider, userProfile.TimeZoneInfo, WorklogSource.Assignee)
+					.ConvertTo<RawIssueWorklog>(JiraConstants.Status.InProgress.Name, _timeProvider, userProfile.TimeZoneInfo, WorklogSource.Assignee)
 					.Where(issueWorklog => issueWorklog.IsBetween(query.StartDate, query.EndDate));
 				result.AddRange(rawIssueWorklogs);
 			}
@@ -192,9 +194,9 @@ namespace Pet.Jira.Infrastructure.Jira
 			CancellationToken cancellationToken = default)
 		{
 			var issueQuery = _queryFactory.Create()
-				.Where("updatedDate", JiraQueryComparisonType.GreaterOrEqual, query.StartDate)
 				.Where("Tester", JiraQueryComparisonType.Equal, JiraQueryMacros.CurrentUser)
 				.Where("type", JiraQueryComparisonType.NotEqual, "Story")
+				.WhereWas("status", JiraConstants.Status.InTesting.Name, query.StartDate, query.EndDate)
 				.OrderBy("updatedDate", JiraQueryOrderType.Desc)
 				.ToString();
 			var issueSearchOptions = CreateEventSearchOptions(issueQuery);
@@ -207,10 +209,13 @@ namespace Pet.Jira.Infrastructure.Jira
 			var changeLogFilter = new Func<IssueChangeLog, bool>(changeLog =>
 				changeLog.Items.Any(item => item.FieldName == JiraConstants.Status.FieldName));
 
+			// Match the "In Testing" status by name in both the filter and ConvertTo, so
+			// the interval detection is driven by the same status the changelog items
+			// were filtered on — no hardcoded status id. See issue #258.
 			var changeLogItemFilter = new Func<IssueChangeLogItem, bool>(changeLogItem =>
 				changeLogItem.FieldName == JiraConstants.Status.FieldName
-				&& (changeLogItem.ToId == "10116" // In Testing
-					|| changeLogItem.FromId == "10116"));
+				&& (changeLogItem.ToValue == JiraConstants.Status.InTesting.Name
+					|| changeLogItem.FromValue == JiraConstants.Status.InTesting.Name));
 
 			var issueChangeLogItems = await _jiraService.GetIssueChangeLogItemsAsync(issues, changeLogFilter, changeLogItemFilter, cancellationToken);
 
@@ -221,7 +226,7 @@ namespace Pet.Jira.Infrastructure.Jira
 					.Where(item => item.ChangeLog.Issue.Key == issue.Key)
 					.OrderBy(item => item.ChangeLog.CreatedDate)
 					.ToList()
-					.ConvertTo<RawIssueWorklog>(query.IssueStatusId, _timeProvider, userProfile.TimeZoneInfo, WorklogSource.Tester)
+					.ConvertTo<RawIssueWorklog>(JiraConstants.Status.InTesting.Name, _timeProvider, userProfile.TimeZoneInfo, WorklogSource.Tester)
 					.Where(issueWorklog => issueWorklog.IsBetween(query.StartDate, query.EndDate));
 				result.AddRange(rawIssueWorklogs);
 			}

--- a/src/Pet.Jira.Infrastructure/Jira/TempoWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Jira/TempoWorklogDataSource.cs
@@ -93,10 +93,34 @@ namespace Pet.Jira.Infrastructure.Jira
         /// <param name="query"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<IEnumerable<IWorklog>> GetRawIssueWorklogsAsync(
-            GetRawIssueWorklogs.Query query,
+        public Task<IEnumerable<IWorklog>> GetAssigneeRawIssueWorklogsAsync(
+            GetAssigneeJiraEvents.Query query,
             CancellationToken cancellationToken = default)
-            => _fallback.GetRawIssueWorklogsAsync(query, cancellationToken);
+            => _fallback.GetAssigneeRawIssueWorklogsAsync(query, cancellationToken);
+
+        /// <summary>
+        /// Raw worklogs (changelog/comment/tester based) are not provided by Tempo —
+        /// delegate to the existing Jira implementation.
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<IEnumerable<IWorklog>> GetTesterRawIssueWorklogsAsync(
+            GetTesterJiraEvents.Query query,
+            CancellationToken cancellationToken = default)
+            => _fallback.GetTesterRawIssueWorklogsAsync(query, cancellationToken);
+
+        /// <summary>
+        /// Raw worklogs (changelog/comment/tester based) are not provided by Tempo —
+        /// delegate to the existing Jira implementation.
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<IEnumerable<IWorklog>> GetCommentRawIssueWorklogsAsync(
+            GetCommentJiraEvents.Query query,
+            CancellationToken cancellationToken = default)
+            => _fallback.GetCommentRawIssueWorklogsAsync(query, cancellationToken);
 
         private static bool IsAuthoredByCurrentUser(TempoWorklogDto worklog, UserProfile userProfile)
             => string.Equals(worklog.Author?.Login, userProfile.Username, StringComparison.OrdinalIgnoreCase);

--- a/src/Pet.Jira.Infrastructure/Mock/MockWorklogDataSource.cs
+++ b/src/Pet.Jira.Infrastructure/Mock/MockWorklogDataSource.cs
@@ -1,4 +1,4 @@
-﻿using Pet.Jira.Application.Worklogs;
+using Pet.Jira.Application.Worklogs;
 using Pet.Jira.Application.Worklogs.Queries;
 using Pet.Jira.Domain.Models.Worklogs;
 using System.Collections.Generic;
@@ -15,9 +15,26 @@ namespace Pet.Jira.Infrastructure.Mock
             return Task.FromResult(MockWorklogStorage.IssueWorklogs.AsEnumerable());
         }
 
-        public Task<IEnumerable<IWorklog>> GetRawIssueWorklogsAsync(GetRawIssueWorklogs.Query query, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<IWorklog>> GetAssigneeRawIssueWorklogsAsync(GetAssigneeJiraEvents.Query query, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(MockWorklogStorage.RawIssueWorklogs.AsEnumerable());
+            return Task.FromResult(FilterBySource(WorklogSource.Assignee));
+        }
+
+        public Task<IEnumerable<IWorklog>> GetTesterRawIssueWorklogsAsync(GetTesterJiraEvents.Query query, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(FilterBySource(WorklogSource.Tester));
+        }
+
+        public Task<IEnumerable<IWorklog>> GetCommentRawIssueWorklogsAsync(GetCommentJiraEvents.Query query, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(FilterBySource(WorklogSource.Comment));
+        }
+
+        private static IEnumerable<IWorklog> FilterBySource(WorklogSource source)
+        {
+            return MockWorklogStorage.RawIssueWorklogs
+                .Where(worklog => worklog is RawIssueWorklog raw && raw.Source == source)
+                .ToList();
         }
     }
 }

--- a/tests/Pet.Jira.UnitTests/Application/Worklogs/Queries/GetWorklogCollectionHandlerTests.cs
+++ b/tests/Pet.Jira.UnitTests/Application/Worklogs/Queries/GetWorklogCollectionHandlerTests.cs
@@ -29,7 +29,13 @@ namespace Pet.Jira.UnitTests.Application.Worklogs.Queries
             _identityServiceMock = new Mock<IIdentityService>();
 
             _mediatorMock
-                .Setup(x => x.Send(It.IsAny<GetRawIssueWorklogs.Query>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.Send(It.IsAny<GetAssigneeJiraEvents.Query>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IEnumerable<IWorklog>)new List<IWorklog>());
+            _mediatorMock
+                .Setup(x => x.Send(It.IsAny<GetTesterJiraEvents.Query>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IEnumerable<IWorklog>)new List<IWorklog>());
+            _mediatorMock
+                .Setup(x => x.Send(It.IsAny<GetCommentJiraEvents.Query>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IEnumerable<IWorklog>)new List<IWorklog>());
             _mediatorMock
                 .Setup(x => x.Send(It.IsAny<GetIssueWorklogs.Query>(), It.IsAny<CancellationToken>()))

--- a/tests/Pet.Jira.UnitTests/Infrastructure/Jira/JiraExtensionsTests.cs
+++ b/tests/Pet.Jira.UnitTests/Infrastructure/Jira/JiraExtensionsTests.cs
@@ -62,9 +62,9 @@ namespace Pet.Jira.UnitTests.Infrastructure.Jira
 
         private static class IssueStatus
         {
-            public static string InProgress = "2";
-            public static string Open = "1";
-            public static string InReview = "3";
+            public static string InProgress = "In Progress";
+            public static string Open = "Open";
+            public static string InReview = "In Review";
         }
 
         class ChangeLogItemConvertToCases : IEnumerable
@@ -73,13 +73,13 @@ namespace Pet.Jira.UnitTests.Infrastructure.Jira
             private readonly string _user1 = "user1";
             private readonly string _user2 = "user2";
 
-            private IssueChangeLogItemDto CreateItem(IssueChangeLogDto changeLog, string author, string fromId, string toId)
+            private IssueChangeLogItemDto CreateItem(IssueChangeLogDto changeLog, string author, string fromValue, string toValue)
             {
                 return new IssueChangeLogItemDto
                 {
                     Author = author,
-                    FromId = fromId,
-                    ToId = toId,
+                    FromValue = fromValue,
+                    ToValue = toValue,
                     ChangeLog = changeLog
                 };
             }


### PR DESCRIPTION
Closes #258.

Оптимизация времени получения событий Jira. Ранее всё делал один тяжёлый запрос `GetRawIssueWorklogs`, который последовательно считал assignee/tester/comment события и мерился в дев-панели одним лумпом.

## Что сделано

**1. Разделение на 3 независимо измеряемых запроса** (цель #1 из issue)
- `GetRawIssueWorklogs` разбит на `GetAssigneeJiraEvents`, `GetTesterJiraEvents`, `GetCommentJiraEvents` — каждый отдельный MediatR-запрос, поэтому `PerformanceBehavior` меряет их по отдельности (`/performance`).
- `IWorklogDataSource` получил три метода вместо одного; обновлены Jira/Tempo/Mock реализации.

**2. Сокращение выборок** (цель #2 из issue)
- Поиск issue для событий запрашивает только поле `summary` (`FetchBasicFields = false`), а не все навигируемые поля.
- Статусы матчатся по **имени** (`ToValue`/`FromValue`), а не по хардкод-id `"3"`/`"10116"`; `JiraConstants.Status` теперь содержит объекты `InProgress`/`InTesting` (Id+Name).
- Основной фильтр tester приведён к виду assignee: `WhereWas("status", "In Testing", …)` вместо широкого `updatedDate >= start`.
- Заодно исправлен скрытый баг tester: в `ConvertTo` уходил id In Progress, хотя элементы фильтровались по In Testing.

**3. Параллелизм**
- `JiraService.GetIssueCommentsAsync` тянет комментарии параллельно (`Parallel.ForEachAsync` + `ConcurrentBag`), как changelog/worklog.
- В `GetWorklogCollection` независимые выборки (assignee/tester/comment + фактические ворклоги + календарь) запускаются через `Task.WhenAll`. Безопасно: scoped `ApplicationDbContext` трогает только календарный путь, и он — одна задача; Джира-хендлеры transient без общего состояния.
  - Компромисс: аллокации в `/performance` перестают быть репрезентативными для этих конкурентных запросов (тайминги пишутся). Оговорено в комментарии.

**4. Чистка**
- Убраны boilerplate XML-доки в `JiraWorklogDataSource`.

## Тесты
Все 102 юнит-теста зелёные. `JiraExtensionsTests` переведён на матчинг по имени статуса; `GetWorklogCollectionHandlerTests` обновлён под 3 запроса.

## Не вошло (обсуждалось, вынесено отдельно)
- Перевод assignee/tester на `assignee/Tester WAS currentUser() DURING (…)` (требует доработки билдера `WhereWas` под макрос без кавычек).
- Удаление ставшего декоративным статус-пикера в UI + `IssueStatusId` из `GetWorklogCollection.Query`/`UserWorklogFilter`.
