### PR TITLE
Blazor Server reconnection resilience + themed overlay (#112)

### DIFF
--- a/src/Pet.Jira.Web/Pages/_Host.cshtml
+++ b/src/Pet.Jira.Web/Pages/_Host.cshtml
@@ -43,7 +43,16 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script src="_framework/blazor.server.js"></script>
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+        // Try harder to reconnect to the same circuit before falling back to reload
+        Blazor.start({
+            reconnectionOptions: {
+                maxRetries: 30,
+                retryIntervalMilliseconds: 2000
+            }
+        });
+    </script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/MudBlazor.Markdown/MudBlazor.Markdown.min.js"></script>
     <script src="scripts/clipboard.js"></script>

--- a/src/Pet.Jira.Web/Pages/_Host.cshtml
+++ b/src/Pet.Jira.Web/Pages/_Host.cshtml
@@ -43,34 +43,39 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script src="_framework/blazor.server.js" autostart="false"></script>
-    <script>
-        // Try harder to reconnect to the same circuit before falling back to reload
-        Blazor.start({
-            reconnectionOptions: {
-                maxRetries: 30,
-                retryIntervalMilliseconds: 2000
-            }
-        });
-    </script>
+    @* Blazor toggles the components-reconnect-* classes on this element and fills
+       the attempt counters; styling in css/custom.css keys off those classes. *@
+    <div id="components-reconnect-modal">
+        <div class="pet-rc__dialog" role="alertdialog" aria-live="assertive">
+            <div class="pet-rc__state pet-rc__state--show">
+                <div class="pet-rc__spinner" aria-hidden="true"></div>
+                <h2 class="pet-rc__title">Соединение потеряно</h2>
+                <p class="pet-rc__text">
+                    Восстанавливаем связь с сервером…
+                    <span class="pet-rc__attempt">
+                        Попытка <span id="components-reconnect-current-attempt">1</span>
+                        из <span id="components-reconnect-max-retries"></span>
+                    </span>
+                </p>
+            </div>
+            @* Terminal state for both 'failed' and 'rejected' — state is gone, reload is the only option. *@
+            <div class="pet-rc__state pet-rc__state--reload">
+                <div class="pet-rc__icon" aria-hidden="true">↻</div>
+                <h2 class="pet-rc__title">Не удалось восстановить соединение</h2>
+                <p class="pet-rc__text">
+                    Связь с сервером не восстановилась, а состояние страницы потеряно.
+                    Перезагрузите страницу, чтобы продолжить работу.
+                </p>
+                <button type="button" class="pet-rc__btn" onclick="location.reload()">
+                    Перезагрузить страницу
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/MudBlazor.Markdown/MudBlazor.Markdown.min.js"></script>
     <script src="scripts/clipboard.js"></script>
-
-    <script>
-        // Wait until a 'reload' button appears
-        new MutationObserver((mutations, observer) => {
-            if (document.querySelector('#components-reconnect-modal h5 a')) {
-                // Now every 10 seconds, see if the server appears to be back, and if so, reload
-                async function attemptReload() {
-                    await fetch(''); // Check the server really is back
-                    location.reload();
-                }
-                observer.disconnect();
-                attemptReload();
-                setInterval(attemptReload, 10000);
-            }
-        }).observe(document.body, { childList: true, subtree: true });
-    </script>
 </body>
 </html>

--- a/src/Pet.Jira.Web/Startup.cs
+++ b/src/Pet.Jira.Web/Startup.cs
@@ -30,19 +30,37 @@ namespace Pet.Jira.Web
 {
 	public class Startup
     {
-        public Startup(IConfiguration configuration)
+        public Startup(IConfiguration configuration, IWebHostEnvironment environment)
         {
             Configuration = configuration;
+            Environment = environment;
         }
 
         public IConfiguration Configuration { get; }
+
+        public IWebHostEnvironment Environment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
-            services.AddServerSideBlazor();
+            services.AddServerSideBlazor(options =>
+                {
+                    // Show detailed circuit errors only in Development
+                    options.DetailedErrors = Environment.IsDevelopment();
+                    // Keep a disconnected circuit for a while so short network
+                    // blips restore the page state without a full reload
+                    options.DisconnectedCircuitRetentionPeriod = TimeSpan.FromMinutes(3);
+                    options.DisconnectedCircuitMaxRetained = 100;
+                })
+                .AddHubOptions(options =>
+                {
+                    // Give the connection more headroom on unstable networks / VPN
+                    options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
+                    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+                    options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+                });
 
 			services.AddMudServices(config =>
             {

--- a/src/Pet.Jira.Web/Startup.cs
+++ b/src/Pet.Jira.Web/Startup.cs
@@ -47,16 +47,15 @@ namespace Pet.Jira.Web
             services.AddRazorPages();
             services.AddServerSideBlazor(options =>
                 {
-                    // Show detailed circuit errors only in Development
                     options.DetailedErrors = Environment.IsDevelopment();
-                    // Keep a disconnected circuit for a while so short network
-                    // blips restore the page state without a full reload
+                    // Retain the disconnected circuit so a reconnect within this window
+                    // restores page state instead of forcing a reload (see _Host.cshtml).
                     options.DisconnectedCircuitRetentionPeriod = TimeSpan.FromMinutes(3);
                     options.DisconnectedCircuitMaxRetained = 100;
                 })
                 .AddHubOptions(options =>
                 {
-                    // Give the connection more headroom on unstable networks / VPN
+                    // Looser timeouts to survive brief drops on unstable networks / VPN.
                     options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
                     options.KeepAliveInterval = TimeSpan.FromSeconds(15);
                     options.HandshakeTimeout = TimeSpan.FromSeconds(30);

--- a/src/Pet.Jira.Web/wwwroot/css/custom.css
+++ b/src/Pet.Jira.Web/wwwroot/css/custom.css
@@ -605,3 +605,141 @@
 }
 .rel-card__date-icon { opacity: .55; }
 
+/* ============================================================
+   Blazor Server reconnection overlay (#components-reconnect-modal),
+   rendered in _Host.cshtml outside the Blazor tree. Colors use
+   --mud-palette-* — they cascade here, so the overlay follows the app's
+   light/dark theme. MudBlazor ships its own styles for this id and loads
+   AFTER this file, hence the body-scoped scrim override below.
+   ============================================================ */
+#components-reconnect-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 10001;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    animation: pet-rc-fade .2s ease both;
+}
+/* body-scoped + !important to outrank MudBlazor's background-color:!important,
+   so the overlay dims the page instead of filling it solid. */
+body #components-reconnect-modal {
+    background: rgba(0, 0, 0, .55) !important;
+}
+#components-reconnect-modal.components-reconnect-show,
+#components-reconnect-modal.components-reconnect-failed,
+#components-reconnect-modal.components-reconnect-rejected {
+    display: flex;
+}
+/* 1s grace before the overlay fades in, so brief blips that reconnect within it
+   never flash the modal. Only 'show' is delayed; the terminal states appear at
+   once. Disappearance is instant — removing the class drops it to display:none,
+   there is no fade-out. */
+#components-reconnect-modal.components-reconnect-show {
+    animation-delay: 1s;
+    pointer-events: none;
+}
+
+.pet-rc__dialog {
+    width: 100%;
+    max-width: 380px;
+    padding: 32px 28px;
+    border-radius: 18px;
+    text-align: center;
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    border: 1px solid var(--mud-palette-lines-default);
+    box-shadow: 0 24px 60px -18px rgba(0, 0, 0, .5);
+    animation: pet-rc-pop .25s cubic-bezier(.2,.7,.2,1) both;
+}
+
+/* Show only the block for the current class; 'failed' and 'rejected' share the
+   reload block (both mean state is unrecoverable). */
+.pet-rc__state { display: none; }
+#components-reconnect-modal.components-reconnect-show .pet-rc__state--show { display: block; }
+#components-reconnect-modal.components-reconnect-failed .pet-rc__state--reload,
+#components-reconnect-modal.components-reconnect-rejected .pet-rc__state--reload { display: block; }
+
+.pet-rc__title {
+    margin: 18px 0 8px;
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+.pet-rc__text {
+    margin: 0;
+    font-size: .9rem;
+    line-height: 1.5;
+    color: var(--mud-palette-text-secondary);
+}
+.pet-rc__attempt {
+    display: block;
+    margin-top: 10px;
+    font-size: .8rem;
+    color: var(--mud-palette-text-secondary);
+    opacity: .8;
+}
+
+.pet-rc__spinner {
+    width: 52px;
+    height: 52px;
+    margin: 0 auto;
+    border-radius: 50%;
+    border: 4px solid rgba(var(--mud-palette-primary-rgb), .18);
+    border-top-color: var(--mud-palette-primary);
+    animation: pet-rc-spin .8s linear infinite;
+}
+
+.pet-rc__icon {
+    display: grid;
+    place-items: center;
+    width: 52px;
+    height: 52px;
+    margin: 0 auto;
+    border-radius: 50%;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--mud-palette-primary);
+    background: rgba(var(--mud-palette-primary-rgb), .12);
+}
+
+/* id-scoped to beat MudBlazor's own button rule (uppercase + 40px auto margin). */
+#components-reconnect-modal .pet-rc__btn {
+    display: block;
+    margin: 22px auto 0 !important;
+    padding: 10px 26px;
+    border: none;
+    border-radius: 999px;
+    font-size: .9rem;
+    font-weight: 600;
+    font-family: inherit;
+    text-transform: none;
+    letter-spacing: normal;
+    color: #fff;
+    background: var(--mud-palette-primary);
+    cursor: pointer;
+    transition: background-color .2s ease, box-shadow .2s ease, transform .1s ease;
+    box-shadow: 0 8px 20px -8px rgba(var(--mud-palette-primary-rgb), .8);
+}
+#components-reconnect-modal .pet-rc__btn:hover {
+    background: var(--mud-palette-primary-darken);
+    box-shadow: 0 10px 26px -8px rgba(var(--mud-palette-primary-rgb), .9);
+}
+#components-reconnect-modal .pet-rc__btn:active { transform: translateY(1px); }
+
+@keyframes pet-rc-spin { to { transform: rotate(360deg); } }
+@keyframes pet-rc-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes pet-rc-pop {
+    from { opacity: 0; transform: translateY(12px) scale(.97); }
+    to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #components-reconnect-modal,
+    .pet-rc__dialog { animation: none; }
+    .pet-rc__spinner { animation-duration: 2s; }
+}
+


### PR DESCRIPTION
Closes #112

Делает переподключение Blazor Server устойчивым и даёт ему понятный интерфейс в теме приложения.

## Серверная часть (Startup.cs)
- Увеличены таймауты SignalR, чтобы кратковременные обрывы на нестабильной сети / VPN не рвали circuit: `ClientTimeoutInterval` 30с→60с, `HandshakeTimeout` 15с→30с.
- Явно зафиксировано удержание отключённого circuit'а (`DisconnectedCircuitRetentionPeriod` 3 мин, `DisconnectedCircuitMaxRetained` 100) — реконнект в пределах этого окна восстанавливает состояние страницы без перезагрузки.
- `DetailedErrors` включён только в Development.

## Клиентский интерфейс (_Host.cshtml + custom.css)
- Кастомный оверлей `#components-reconnect-modal` вместо стандартной серой плашки.
- Два состояния: спиннер с живым счётчиком попыток (пока переподключение ещё возможно) и единое терминальное состояние **«Перезагрузить»**, общее для случаев `failed` и `rejected` (в обоих состояние страницы уже не вернуть).
- Тема через живые переменные `--mud-palette-*` — оверлей следует за светлой/тёмной темой приложения; правило со `body`-скоупом + `!important`, чтобы перебить собственные стили MudBlazor для этого id.
- **Grace-окно 1с** перед появлением оверлея: короткие блики, которые успевают переподключиться в пределах окна, не вызывают мелькания плашки; исчезновение — мгновенное.
- Используется дефолтный механизм переподключения Blazor (функциональная форма `retryIntervalMilliseconds` с backoff на .NET 8 молча игнорируется).

## Проверка
Проверено в mock-режиме на реальном обрыве/восстановлении сервера: короткие блики остаются невидимыми, при более длинном обрыве показывается спиннер с живым счётчиком «Попытка N из 8», при восстановлении оверлей исчезает мгновенно, а терминальное состояние предлагает единственное действие — «Перезагрузить». Проверено в светлой и тёмной темах.

🤖 Generated with [Claude Code](https://claude.com/claude-code)