### PR TITLE
fix: start date picker weeks on Monday (#253)

### DIFF
--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogDayItemDialog.razor
@@ -7,6 +7,7 @@
         <MudForm @ref="_form">
             <MudPaper Elevation="0" Class="pet-worklog-day-item-dialog">
                 <MudDatePicker Label="Date" @bind-Date="_model.Worklog.Date"
+                               FirstDayOfWeek="DayOfWeek.Monday"
                                Required="true" RequiredError="Date is required" />
                 <MudTimePicker Label="Start time" @bind-Time="_model.Worklog.StartTime" Editable="true"
                                Required="true" RequiredError="Start time is required" />

--- a/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor
+++ b/src/Pet.Jira.Web/Components/Worklogs/WorklogFilter.razor
@@ -9,7 +9,8 @@
 
 <MudPaper Class="flex-none pa-4" Square="true" Outlined="true">
     <MarkdownTooltip Markdown="worklog-filter-date-range" RootClass="pet-full-width">
-        <MudDateRangePicker Label="Date range" @bind-DateRange="_model.Filter.DateRange" />
+        <MudDateRangePicker Label="Date range" @bind-DateRange="_model.Filter.DateRange"
+                            FirstDayOfWeek="DayOfWeek.Monday" />
     </MarkdownTooltip>
     <MarkdownTooltip Markdown="worklog-filter-daily-working-start-time" RootClass="pet-full-width">
         <MudTimePicker Label="Daily working start time" @bind-Time="_model.Filter.DailyWorkingStartTime" Editable="true" />


### PR DESCRIPTION
Closes #253

## Что сделано

Оба date-пикера в разделе Worklogs получили явный `FirstDayOfWeek="DayOfWeek.Monday"`:

- `MudDateRangePicker` в `WorklogFilter.razor` (фильтр Date range)
- `MudDatePicker` в `WorklogDayItemDialog.razor` (диалог New worklog)

## Почему так

`MudBaseDatePicker.FirstDayOfWeek` по умолчанию берётся из `CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek`. Локализация в проекте не настраивается, поэтому используется культура процесса — в контейнере она даёт воскресенье. В Blazor Server культура серверная, а не браузерная, так что подтянуть её из клиента нельзя — явное значение надёжнее.

Альтернатива с переводом приложения на `ru-RU` отклонена: интерфейс англоязычный, а смена культуры заодно поменяла бы формат дат и чисел во всём UI.

## Проверка

- `dotnet build` — 0 errors, 0 warnings.
- Визуально в mock-режиме: в обоих календарях шапка `Mon Tue Wed Thu Fri Sat Sun`, числа разложены верно (1 июля 2026 под Wed, 27 июля под Mon). Ошибок в консоли нет.

Юнит-тестов нет намеренно: проверять нечего, кроме статического значения атрибута в разметке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
