### PR TITLE
fix: powershell-шаги деплоя ломались на не-ASCII символе

### DIFF
--- a/.github/workflows/deploy-iis.yml
+++ b/.github/workflows/deploy-iis.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to deploy, for example v1.6.0'
+        description: 'Published release tag to deploy, for example v1.6.0 (drafts have no downloadable asset)'
         required: true
         type: string
 
@@ -29,6 +29,10 @@ jobs:
     steps:
     # No checkout and no build: the site is deployed from the artifact the Release
     # workflow built and tested on the tag, so production matches a known release.
+    #
+    # Keep every powershell step ASCII-only. The runner writes the step to a UTF-8 file
+    # without a BOM and Windows PowerShell reads it in the system codepage, so a non-ASCII
+    # character arrives mangled and can break parsing before a single line runs.
     - name: Download and unpack the release artifact
       shell: powershell
       run: |
@@ -43,7 +47,7 @@ jobs:
         try {
             Invoke-WebRequest -Uri $url -OutFile $archive -UseBasicParsing
         } catch {
-            throw "Cannot download $asset — releases published before the Release workflow existed carry no artifact. $($_.Exception.Message)"
+            throw "Cannot download $asset. The release has to be published and built by the Release workflow: a draft keeps its asset private and older releases carry none. $($_.Exception.Message)"
         }
 
         if (Test-Path $unpacked) { Remove-Item $unpacked -Recurse -Force }


### PR DESCRIPTION
Первый прогон нового деплоя ([run 30271802557](https://github.com/tolmachev-pravo/pet-jira-copilot/actions/runs/30271802557)) упал не на скачивании артефакта, а на разборе самого скрипта:

```
ParserError: Unexpected token 'releases' in expression or statement
+     throw "Cannot download $asset â€” releases published before the R ...
```

Раннер записывает шаг в UTF-8 файл без BOM, а Windows PowerShell читает его в системной кодировке — тире `—` приезжает искажённым и ломает парсинг до выполнения первой строки. Воспроизвёл: та же строка, прогнанная через cp1251 и cp1252, даёт ровно эту ошибку в обеих кодировках, ASCII-вариант парсится чисто.

Правка: сообщение переписано на ASCII, добавлен комментарий-предупреждение к шагам, чтобы не наступить снова. Проверка теперь простая и машинная — в powershell-шагах не должно быть байтов выше 0x7F.

Заодно уточнено описание входа `tag`: у драфта ассет приватный, поэтому раскатать можно только опубликованный релиз.

Сайт при этом не остался лежать: `Start AppPool` с `if: always()` отработал и поднял пул, несмотря на упавший предыдущий шаг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
