### PR TITLE
Ребрендинг в Chronos: ссылки на репозиторий

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -35,7 +35,7 @@ Pre-release (тег с дефисом, например `v1.6.0-rc.1`) на пр
 ### 🧰 Прочее
 - <Рефакторинг, документация, инфраструктура.>
 
-**Полный список изменений:** https://github.com/tolmachev-pravo/pet-jira-copilot/compare/vA.B.C...vX.Y.Z
+**Полный список изменений:** https://github.com/tolmachev-pravo/chronos/compare/vA.B.C...vX.Y.Z
 
 ---
 

--- a/.github/scripts/build-release-notes.sh
+++ b/.github/scripts/build-release-notes.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 tag="${1:?usage: build-release-notes.sh <tag>}"
-repository_url="https://github.com/tolmachev-pravo/pet-jira-copilot"
+repository_url="https://github.com/tolmachev-pravo/chronos"
 
 previous_tag="$(git describe --tags --abbrev=0 --match 'v*' "${tag}^" 2>/dev/null || true)"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Chronos is an application designed to simplify and automate the process of filling out Jira worklogs. It allows users to log their work time more efficiently and effortlessly.
 
-![image](https://github.com/tolmachev-pravo/pet-jira-copilot/assets/62241382/009697f2-8e71-4473-87a2-0a82c72f6761)
+![image](https://github.com/tolmachev-pravo/chronos/assets/62241382/009697f2-8e71-4473-87a2-0a82c72f6761)
 
 # Features
 * Seamless integration with Jira for authentication

--- a/src/Chronos.Web/Components/Releases/ReleaseOptions.cs
+++ b/src/Chronos.Web/Components/Releases/ReleaseOptions.cs
@@ -10,7 +10,7 @@ namespace Chronos.Web.Components.Releases
         /// <summary>
         /// Repository in <c>owner/name</c> form whose releases are displayed.
         /// </summary>
-        public string Repository { get; set; } = "tolmachev-pravo/pet-jira-copilot";
+        public string Repository { get; set; } = "tolmachev-pravo/chronos";
 
         /// <summary>
         /// Maximum number of releases to show.

--- a/src/Chronos.Web/Shared/MainLayout.razor
+++ b/src/Chronos.Web/Shared/MainLayout.razor
@@ -30,11 +30,8 @@
                 <circle cx="50" cy="50" r="5" fill="#E3A93B" />
             </svg>
             <MudText Typo="Typo.h6" Class="ml-2 pet-not-display-on-480">Chronos</MudText>
-            @* Points at the repository's actual name, matching GitHub:Releases:Repository in
-               appsettings.json. The namespace rename swept this URL along with the code, but the
-               repository itself has not been renamed yet, so Chronos would 404 here. Flip both
-               together once it is. *@
-            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/tolmachev-pravo/pet-jira-copilot" Target="_blank" />
+            @* Keep in step with GitHub:Releases:Repository in appsettings.json. *@
+            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/tolmachev-pravo/chronos" Target="_blank" />
             <MudTooltip Text="@(_model.Theme.IsDarkMode ? "Dark mode" : "Light mode")">
                 <MudToggleIconButton Toggled="@_model.Theme.IsDarkMode"
                                      Icon="@Icons.Material.Filled.LightMode"

--- a/src/Chronos.Web/appsettings.json
+++ b/src/Chronos.Web/appsettings.json
@@ -9,7 +9,7 @@
   "AllowedHosts": "*",
   "GitHub": {
     "Releases": {
-      "Repository": "tolmachev-pravo/pet-jira-copilot",
+      "Repository": "tolmachev-pravo/chronos",
       "MaxCount": 20,
       "CacheMinutes": 10,
       "MaxRetries": 2,

--- a/src/Chronos.Web/faq.md
+++ b/src/Chronos.Web/faq.md
@@ -25,5 +25,5 @@ Sometimes Jira may require a captcha after a certain number of login errors. In 
 ##### Do you have any wishes, suggestions, comments, or questions?
 If you have any wishes, suggestions, comments, or questions, you can reach out to us through the following channels:
 
-GitHub Issues: https://github.com/tolmachev-pravo/pet-jira-copilot/issues
-GitHub Discussions: https://github.com/tolmachev-pravo/pet-jira-copilot/discussions
+GitHub Issues: https://github.com/tolmachev-pravo/chronos/issues
+GitHub Discussions: https://github.com/tolmachev-pravo/chronos/discussions


### PR DESCRIPTION
Слой 3 ребрендинга из issue #226, после ручного переименования репозитория `pet-jira-copilot` → `chronos`. Стек поверх #272.

Приведены к новому имени: ссылка в AppBar, раздел Releases (и значение в `appsettings.json`, и дефолт в `ReleaseOptions`), FAQ, шаблон релизных заметок и скрипт их сборки, URL скриншота в README.

## Заодно снято недоразумение

Каноничное имя репозитория всё это время было `pet-jira-copilot` — `appsettings.json` и `ReleaseOptions.cs` были корректны. Неверной была ссылка в AppBar на `Pet.Jira`, и она не выглядела сломанной только потому, что репозиторий когда-то так назывался и GitHub держит редирект.

## Проверено

Раздел Releases подтягивает реальные заметки из GitHub API уже по новому имени, ошибок на сервере нет. Скрипт релизных заметок генерирует `compare/v1.6.0...v1.7.0` с новым путём.

Перед изменением URL картинки в README проверил, что asset-ссылка выживает переименование: старая отдаёт 301 на новую, новая — 302 на S3. То есть замена просто убирает лишний хоп.

## Нужно сделать руками на сервере

`deploy-iis.yml` исключает `appsettings.json` из копирования, так что на проде живёт своя копия. Если в ней переопределён `GitHub:Releases:Repository`, его надо поправить — иначе раздел Releases продолжит ходить по старому имени через редирект. Работать будет, но лучше выровнять.

Локальный `git remote` тоже переведён на новое имя (он оставался на старом и работал через редирект) — это вне репозитория, отмечаю для полноты.

🤖 Generated with [Claude Code](https://claude.com/claude-code)