### PR TITLE
Ребрендинг в Chronos: имя релизного артефакта и деплой старых тегов

### DIFF
--- a/.github/workflows/deploy-iis.yml
+++ b/.github/workflows/deploy-iis.yml
@@ -38,16 +38,32 @@ jobs:
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-        $asset = "pet-jira-copilot-$env:RELEASE_TAG.zip"
-        $url = "https://github.com/${{ github.repository }}/releases/download/$env:RELEASE_TAG/$asset"
-        $archive = Join-Path $env:RUNNER_TEMP $asset
+        # Two names are tried in turn. The rename to Chronos (issue #226) changed the asset
+        # name, but releases published before it keep the old one forever, so deploying or
+        # rolling back to an older tag has to still find its archive.
+        $candidates = @(
+            "chronos-$env:RELEASE_TAG.zip",
+            "pet-jira-copilot-$env:RELEASE_TAG.zip"
+        )
         $unpacked = Join-Path $env:RUNNER_TEMP "release"
+        $archive = $null
 
-        Write-Host "Downloading $url"
-        try {
-            Invoke-WebRequest -Uri $url -OutFile $archive -UseBasicParsing
-        } catch {
-            throw "Cannot download $asset. The release has to be published and built by the Release workflow: a draft keeps its asset private and older releases carry none. $($_.Exception.Message)"
+        foreach ($asset in $candidates) {
+            $url = "https://github.com/${{ github.repository }}/releases/download/$env:RELEASE_TAG/$asset"
+            $target = Join-Path $env:RUNNER_TEMP $asset
+            Write-Host "Trying $url"
+            try {
+                Invoke-WebRequest -Uri $url -OutFile $target -UseBasicParsing
+                $archive = $target
+                Write-Host "Downloaded $asset"
+                break
+            } catch {
+                Write-Host "Not available under this name: $($_.Exception.Message)"
+            }
+        }
+
+        if (-not $archive) {
+            throw "Cannot download the release archive for $env:RELEASE_TAG under any known asset name. The release has to be published and built by the Release workflow: a draft keeps its asset private and older releases carry none."
         }
 
         if (Test-Path $unpacked) { Remove-Item $unpacked -Recurse -Force }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      # Named once: the packaging step and the upload step must never disagree, and the
+      # deploy workflow downloads the asset by exactly this name.
+      ARTIFACT: chronos-${{ github.ref_name }}.zip
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -47,13 +52,13 @@ jobs:
     - name: Package artifact
       run: |
         mkdir -p artifact
-        (cd publish && zip -qr "../artifact/pet-jira-copilot-${GITHUB_REF_NAME}.zip" .)
+        (cd publish && zip -qr "../artifact/${ARTIFACT}" .)
 
     - name: Create draft release with the artifact
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        asset="artifact/pet-jira-copilot-${GITHUB_REF_NAME}.zip"
+        asset="artifact/${ARTIFACT}"
         if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
           echo "Release $GITHUB_REF_NAME already exists — replacing its artifact, notes are left untouched."
           gh release upload "$GITHUB_REF_NAME" "$asset" --clobber

--- a/src/Chronos.Infrastructure/Data/Contexts/ApplicationDbContextFactory.cs
+++ b/src/Chronos.Infrastructure/Data/Contexts/ApplicationDbContextFactory.cs
@@ -8,6 +8,8 @@ namespace Chronos.Infrastructure.Data.Contexts
         public ApplicationDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            // Keep in step with ServiceCollectionExtensions: the pre-Chronos file name is
+            // deliberate, see the comment there before changing it.
             optionsBuilder.UseSqlite("Data Source = JiraCopilot.sqlite3");
 
             return new ApplicationDbContext(optionsBuilder.Options);

--- a/src/Chronos.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Chronos.Infrastructure/ServiceCollectionExtensions.cs
@@ -71,6 +71,11 @@ namespace Chronos.Infrastructure
             services.AddSingleton<ILoginMemoryCache, LoginMemoryCache>();
             services.AddTransient<IMemoryCache<string, Issue>, IssueMemoryCache>();
 
+			// The file name predates the rename to Chronos (issue #226) and stays as it is on
+			// purpose. The path is relative, so on the server it resolves inside the deployed
+			// site folder. Renaming it here without renaming the file on the server first, with
+			// the AppPool stopped, silently creates an empty database and hides every existing
+			// user, their extensions and their encrypted secrets.
 			services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlite("Data Source = JiraCopilot.sqlite3"));
 


### PR DESCRIPTION
Слой 4 ребрендинга из issue #226. Стек поверх #273.

Release workflow пакует `chronos-<tag>.zip`. Имя задано **один раз** в job-level `env`: раньше оно дублировалось в шаге упаковки и в шаге загрузки, и эти два места могли разъехаться.

## Fallback — не теоретическая страховка

Релизы, опубликованные до этой правки, навсегда сохраняют актив с префиксом `pet-jira-copilot-`, поэтому deploy workflow перебирает два имени по порядку. Проверено на реальных релизах:

| Тег | `chronos-<tag>.zip` | `pet-jira-copilot-<tag>.zip` |
|---|---|---|
| v1.7.0 | 404 | 206 |
| v1.6.0 | 404 | 206 |

Без перебора деплой уже опубликованного тега через `workflow_dispatch` — или откат на него — сломался бы сразу после мерджа. Проверял байтовым диапазоном, чтобы не тянуть архивы целиком.

Шаг скачивания остался **ASCII-only**, как требует комментарий в шапке job'а: runner отдаёт шаг в UTF-8 без BOM, а Windows PowerShell читает его в системной кодировке, поэтому не-ASCII символ приезжает искажённым и может сломать парсинг до запуска первой строки. У этого файла такая поломка уже была, поэтому все 5 PowerShell-шагов дополнительно прогнаны через парсер PowerShell.

## Почему файл БД остаётся `JiraCopilot.sqlite3`

Путь относительный, на проде база лежит в папке сайта. Переименование в коде без предварительного переименования файла на сервере при остановленном AppPool молча создаёт **пустую** базу: пользователи, их расширения и зашифрованные секреты остаются в старом файле, и снаружи это выглядит как полная потеря данных. Риск не оправдан ради идентификатора, которого пользователь никогда не видит.

Причина записана в код рядом со строкой подключения — иначе следующий, кто дочищает ребрендинг, переименует файл «за компанию» и уронит прод.

Отдельно: `SetApplicationName("Chronos")` в DataProtection не тронут нигде во всём ребрендинге. Его изменение сделало бы нерасшифровываемыми сохранённые пароли Jira и токены Яндекс.Календаря у всех пользователей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)