### PR TITLE
Ребрендинг в Chronos: CSS-префикс pet- → chr-

### DIFF
--- a/src/Chronos.Web/Components/Extensions/ExtensionsPage.razor
+++ b/src/Chronos.Web/Components/Extensions/ExtensionsPage.razor
@@ -1,7 +1,7 @@
 @using Chronos.Web.Components.Extensions.Jira
 @using Chronos.Web.Components.Extensions.YandexCalendar
 
-<div class="pet-section-head">
+<div class="chr-section-head">
     <MudText Typo="Typo.h5" Style="font-weight:700">Extensions</MudText>
     <MudText Typo="Typo.body2" Style="opacity:.6" Class="mt-1">
         Подключайте внешние сервисы — и списывайте время автоматически.

--- a/src/Chronos.Web/Components/Features/FeaturesPage.razor
+++ b/src/Chronos.Web/Components/Features/FeaturesPage.razor
@@ -1,7 +1,7 @@
 @using Chronos.Web.Components.Common
 
 <div class="feat-page">
-    <div class="pet-section-head">
+    <div class="chr-section-head">
         <MudText Typo="Typo.h5" Style="font-weight:700">Features</MudText>
         <MudText Typo="Typo.body2" Style="opacity:.6" Class="mt-1">
             Свежие возможности приложения — что нового и как этим пользоваться.

--- a/src/Chronos.Web/Components/Markdown/ComponentMarkdownViewer.razor
+++ b/src/Chronos.Web/Components/Markdown/ComponentMarkdownViewer.razor
@@ -1,3 +1,3 @@
-﻿<MudElement Class="d-flex flex-wrap gap-4 border-none pet-component-markdown">
+﻿<MudElement Class="d-flex flex-wrap gap-4 border-none chr-component-markdown">
     <MudMarkdown Value="@Value" />
 </MudElement>

--- a/src/Chronos.Web/Components/Releases/ReleasesPage.razor
+++ b/src/Chronos.Web/Components/Releases/ReleasesPage.razor
@@ -1,7 +1,7 @@
 @using Chronos.Web.Components.Common
 
 <div class="rel-page">
-    <div class="pet-section-head">
+    <div class="chr-section-head">
         <MudText Typo="Typo.h5" Style="font-weight:700">Releases</MudText>
         <MudText Typo="Typo.body2" Style="opacity:.6" Class="mt-1">
             История релизов приложения — прямиком со страницы релизов в GitHub.

--- a/src/Chronos.Web/Components/Worklogs/ActualWorklogItem.razor
+++ b/src/Chronos.Web/Components/Worklogs/ActualWorklogItem.razor
@@ -17,7 +17,7 @@
         <MudElement Class="static-time-spent-container flex-none d-flex justify-end align-center gap-2">
             <MudTextField @bind-Value="@Entity.RemainingTimeSpent"
                           Disabled="true"
-                          Class="pet-input-control"
+                          Class="chr-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
             <MudIconButton Size="Size.Small"

--- a/src/Chronos.Web/Components/Worklogs/CalendarWorklogItem.razor
+++ b/src/Chronos.Web/Components/Worklogs/CalendarWorklogItem.razor
@@ -33,7 +33,7 @@
     <MudElement Class="scalable-time-spent-container flex-none d-flex justify-end">
         <MudElement Class="static-time-spent-container flex-none d-flex justify-end align-center gap-2">
             <MudTextField @bind-Value="@Entity.RemainingTimeSpent"
-                          Class="pet-input-control"
+                          Class="chr-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
             @if (_isAdding)

--- a/src/Chronos.Web/Components/Worklogs/CalendarWorklogMenu.razor
+++ b/src/Chronos.Web/Components/Worklogs/CalendarWorklogMenu.razor
@@ -4,7 +4,7 @@
          Color="@Color"
          Size="Size.Small"
          Dense="true"
-         Class="pet-vertical-align-middle"
+         Class="chr-vertical-align-middle"
          AnchorOrigin="Origin.BottomLeft"
          TransformOrigin="Origin.TopLeft">
     <ChildContent>

--- a/src/Chronos.Web/Components/Worklogs/EstimatedActualWorklogItem.razor
+++ b/src/Chronos.Web/Components/Worklogs/EstimatedActualWorklogItem.razor
@@ -1,8 +1,8 @@
 ﻿<MudElement Class="gap-2 d-flex flex-wrap border-none align-center"
-             Style="opacity:var(--pet-logged-opacity)">
+             Style="opacity:var(--chr-logged-opacity)">
     <MudElement Class="flex-auto d-flex gap-1 align-center" Style="width: 150px">
         <MudPaper Class="flex-none" Width="124px" Elevation="0" />
-        <MudElement Class="pl-2 pet-not-display-on-600">
+        <MudElement Class="pl-2 chr-not-display-on-600">
             <MudButton Href="@Entity.Issue.Link"
                        Size="Size.Small"
                        Target="_blank"
@@ -17,7 +17,7 @@
         <MudElement Class="static-time-spent-container flex-none d-flex justify-end align-center gap-2">
             <MudTextField @bind-Value="@Entity.RemainingTimeSpent"
                           Disabled="true"
-                          Class="pet-input-control"
+                          Class="chr-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
             <MudIconButton Size="Size.Small"

--- a/src/Chronos.Web/Components/Worklogs/WorklogDay.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogDay.razor
@@ -1,21 +1,21 @@
 @using MudBlazor
 @using Chronos.Web.Common
 
-<tr class="pet-table-summary-tr">
+<tr class="chr-table-summary-tr">
     <td>
         <div class="@DayHeaderClass">
             <WorklogDayMenu Entity="@Entity" OnCreatedPressed="AddWorklogAsync" />
-            <div class="pet-day-date">
-                <div class="pet-day-date-main">@DayDateText</div>
-                <div class="pet-day-date-sub">@Entity.Date.Year</div>
+            <div class="chr-day-date">
+                <div class="chr-day-date-main">@DayDateText</div>
+                <div class="chr-day-date-sub">@Entity.Date.Year</div>
             </div>
-            <div class="pet-day-progress">
-                <div class="pet-day-bar-track">
-                    <div class="pet-day-bar-fill" style="width:@(Entity.Progress)%"></div>
+            <div class="chr-day-progress">
+                <div class="chr-day-bar-track">
+                    <div class="chr-day-bar-fill" style="width:@(Entity.Progress)%"></div>
                 </div>
-                <div class="pet-day-bar-label">
+                <div class="chr-day-bar-label">
                     <span>@FormatTime(Entity.ActualWorklogTimeSpent) / @FormatTime(Entity.WorklogTimeSpent)</span>
-                    <span class="pet-day-bar-pct">@ProgressPercent</span>
+                    <span class="chr-day-bar-pct">@ProgressPercent</span>
                 </div>
             </div>
         </div>

--- a/src/Chronos.Web/Components/Worklogs/WorklogDay.razor.cs
+++ b/src/Chronos.Web/Components/Worklogs/WorklogDay.razor.cs
@@ -27,10 +27,10 @@ namespace Chronos.Web.Components.Worklogs
         {
             get
             {
-                if (Entity.IsWeekend) return "pet-day-header pet-day-header-weekend";
-                if (Entity.Progress >= 100) return "pet-day-header pet-day-header-done";
-                if (Entity.Progress > 0) return "pet-day-header pet-day-header-progress";
-                return "pet-day-header";
+                if (Entity.IsWeekend) return "chr-day-header chr-day-header-weekend";
+                if (Entity.Progress >= 100) return "chr-day-header chr-day-header-done";
+                if (Entity.Progress > 0) return "chr-day-header chr-day-header-progress";
+                return "chr-day-header";
             }
         }
 

--- a/src/Chronos.Web/Components/Worklogs/WorklogDayChip.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogDayChip.razor
@@ -1,7 +1,7 @@
 ﻿<MudChip T="string" Color="@Color" Size=@Size Variant=@Variant Label="true">
     @if (!string.IsNullOrEmpty(@Caption))
     {
-        <b class="pet-not-display-on-480">@Caption: </b>
+        <b class="chr-not-display-on-480">@Caption: </b>
     }
     @Value
 </MudChip>

--- a/src/Chronos.Web/Components/Worklogs/WorklogDayItemDialog.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogDayItemDialog.razor
@@ -5,7 +5,7 @@
 <MudDialog>
     <DialogContent>
         <MudForm @ref="_form">
-            <MudPaper Elevation="0" Class="pet-worklog-day-item-dialog">
+            <MudPaper Elevation="0" Class="chr-worklog-day-item-dialog">
                 <MudDatePicker Label="Date" @bind-Date="_model.Worklog.Date"
                                FirstDayOfWeek="DayOfWeek.Monday"
                                Required="true" RequiredError="Date is required" />

--- a/src/Chronos.Web/Components/Worklogs/WorklogDayMenu.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogDayMenu.razor
@@ -1,6 +1,6 @@
 ﻿@using Chronos.Web.Components.Markdown
 
-<MudMenu Icon="@Icon" Color="@Color" Size="Size.Small" Dense="true" Class="pet-vertical-align-middle"
+<MudMenu Icon="@Icon" Color="@Color" Size="Size.Small" Dense="true" Class="chr-vertical-align-middle"
          AnchorOrigin=Origin.BottomLeft TransformOrigin=Origin.TopLeft Label="@Label">
     <ChildContent>
         <MudMenuItem OnClick="(async () => await AddCustomWorklog())">Add custom worklog</MudMenuItem>

--- a/src/Chronos.Web/Components/Worklogs/WorklogFilter.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogFilter.razor
@@ -1,23 +1,23 @@
 ﻿@using Chronos.Web.Components.Markdown
 
 <style>
-    .pet-full-width {
+    .chr-full-width {
         width: 100% !important;
     }
 </style>
 
 <MudPaper Class="flex-none pa-4" Square="true" Outlined="true">
-    <MarkdownTooltip Markdown="worklog-filter-date-range" RootClass="pet-full-width">
+    <MarkdownTooltip Markdown="worklog-filter-date-range" RootClass="chr-full-width">
         <MudDateRangePicker Label="Date range" @bind-DateRange="_model.Filter.DateRange"
                             FirstDayOfWeek="DayOfWeek.Monday" />
     </MarkdownTooltip>
-    <MarkdownTooltip Markdown="worklog-filter-daily-working-start-time" RootClass="pet-full-width">
+    <MarkdownTooltip Markdown="worklog-filter-daily-working-start-time" RootClass="chr-full-width">
         <MudTimePicker Label="Daily working start time" @bind-Time="_model.Filter.DailyWorkingStartTime" Editable="true" />
     </MarkdownTooltip>
-    <MarkdownTooltip Markdown="worklog-filter-daily-working-end-time" RootClass="pet-full-width">
+    <MarkdownTooltip Markdown="worklog-filter-daily-working-end-time" RootClass="chr-full-width">
         <MudTimePicker Label="Daily working end time" @bind-Time="_model.Filter.DailyWorkingEndTime" Editable="true" />
     </MarkdownTooltip>
-    <MarkdownTooltip Markdown="worklog-filter-lunch-time" RootClass="pet-full-width">
+    <MarkdownTooltip Markdown="worklog-filter-lunch-time" RootClass="chr-full-width">
         <MudTimePicker Label="Lunch duration" @bind-Time="_model.Filter.LunchTime" Editable="true" />
     </MarkdownTooltip>
 </MudPaper>

--- a/src/Chronos.Web/Components/Worklogs/WorklogItem.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogItem.razor
@@ -18,7 +18,7 @@
         <MudElement Class="static-time-spent-container flex-none d-flex justify-end align-center gap-2">
             <MudTextField @bind-Value="@Entity.RemainingTimeSpent"
                           Disabled="false"
-                          Class="pet-input-control"
+                          Class="chr-input-control"
                           Variant="Variant.Text"
                           IconSize="Size.Small" />
             @if (_isAdding)

--- a/src/Chronos.Web/Components/Worklogs/WorklogList.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogList.razor
@@ -32,34 +32,34 @@
         min-height: 32px;
     }
 
-    .pet-input-control {
+    .chr-input-control {
         margin-top: 0px
     }
 
-    .pet-button {
+    .chr-button {
         padding: 4px !important
     }
 
-    .pet-input-control > .mud-input-control-input-container > div.mud-input.mud-input-text {
+    .chr-input-control > .mud-input-control-input-container > div.mud-input.mud-input-text {
         margin-top: 0px !important;
     }
 
-    .pet-table-mud-badge-counter {
+    .chr-table-mud-badge-counter {
         margin-left: 0px
     }
 
-    .pet-paper {
+    .chr-paper {
         background-color: inherit;
     }
 
-    .pet-table-summary-tr td {
+    .chr-table-summary-tr td {
         padding: 0 !important;
     }
 </style>
 
 @if (Items.IsEmpty())
 {
-    <MudPaper Class="pa-4 pet-paper" Elevation="0">
+    <MudPaper Class="pa-4 chr-paper" Elevation="0">
         <LatestFeaturesViewer FallbackMessage="To display a list of actual and estimated worklogs, set the search options and click the 'Search' button" />
     </MudPaper>
 }

--- a/src/Chronos.Web/Components/Worklogs/WorklogListPage.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogListPage.razor
@@ -2,17 +2,17 @@
 @page "/worklogs"
 
 <style>
-    .pet-filter-container {
+    .chr-filter-container {
         width: 280px;
     }
 
     @@media (max-width:480px) { /* smartphones, Android phones, landscape iPhone */
-        .pet-filter-container {
+        .chr-filter-container {
             width: 100%;
         }
     }
 
-    .pet-backgorund-container {
+    .chr-background-container {
         background-color: inherit;
     }
 </style>
@@ -21,11 +21,11 @@
     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
 </MudOverlay>
 
-<MudPaper Class="d-flex flex-wrap gap-4 border-none mb-4 pet-backgorund-container flex-grow-1" Outlined="true">
-    <MudElement Class="pet-filter-container">
+<MudPaper Class="d-flex flex-wrap gap-4 border-none mb-4 chr-background-container flex-grow-1" Outlined="true">
+    <MudElement Class="chr-filter-container">
         <WorklogFilter OnSearchPressed="SearchAsync" />
     </MudElement>
-    <MudPaper Class="flex-1 pet-horizontal-center" Outlined="true">
+    <MudPaper Class="flex-1 chr-horizontal-center" Outlined="true">
         <WorklogList Items="@Model.Items"></WorklogList>
     </MudPaper>
 </MudPaper>

--- a/src/Chronos.Web/Components/Worklogs/WorklogMenu.razor
+++ b/src/Chronos.Web/Components/Worklogs/WorklogMenu.razor
@@ -1,6 +1,6 @@
 ﻿@using Chronos.Web.Components.Markdown
 
-<MudMenu Icon="@Icon" Color="@Color" Size="Size.Small" Dense="true" Class="pet-vertical-align-middle"
+<MudMenu Icon="@Icon" Color="@Color" Size="Size.Small" Dense="true" Class="chr-vertical-align-middle"
          AnchorOrigin=Origin.BottomLeft TransformOrigin=Origin.TopLeft Label="@Label">
     <ChildContent>
         <MudMenuItem OnClick="(async () => await CopyToClipboardInReviewAsync())">Copy as In review</MudMenuItem>

--- a/src/Chronos.Web/Pages/_Host.cshtml
+++ b/src/Chronos.Web/Pages/_Host.cshtml
@@ -57,27 +57,27 @@
     @* Blazor toggles the components-reconnect-* classes on this element and fills
        the attempt counters; styling in css/custom.css keys off those classes. *@
     <div id="components-reconnect-modal">
-        <div class="pet-rc__dialog" role="alertdialog" aria-live="assertive">
-            <div class="pet-rc__state pet-rc__state--show">
-                <div class="pet-rc__spinner" aria-hidden="true"></div>
-                <h2 class="pet-rc__title">Соединение потеряно</h2>
-                <p class="pet-rc__text">
+        <div class="chr-rc__dialog" role="alertdialog" aria-live="assertive">
+            <div class="chr-rc__state chr-rc__state--show">
+                <div class="chr-rc__spinner" aria-hidden="true"></div>
+                <h2 class="chr-rc__title">Соединение потеряно</h2>
+                <p class="chr-rc__text">
                     Восстанавливаем связь с сервером…
-                    <span class="pet-rc__attempt">
+                    <span class="chr-rc__attempt">
                         Попытка <span id="components-reconnect-current-attempt">1</span>
                         из <span id="components-reconnect-max-retries"></span>
                     </span>
                 </p>
             </div>
             @* Terminal state for both 'failed' and 'rejected' — state is gone, reload is the only option. *@
-            <div class="pet-rc__state pet-rc__state--reload">
-                <div class="pet-rc__icon" aria-hidden="true">↻</div>
-                <h2 class="pet-rc__title">Не удалось восстановить соединение</h2>
-                <p class="pet-rc__text">
+            <div class="chr-rc__state chr-rc__state--reload">
+                <div class="chr-rc__icon" aria-hidden="true">↻</div>
+                <h2 class="chr-rc__title">Не удалось восстановить соединение</h2>
+                <p class="chr-rc__text">
                     Связь с сервером не восстановилась, а состояние страницы потеряно.
                     Перезагрузите страницу, чтобы продолжить работу.
                 </p>
-                <button type="button" class="pet-rc__btn" onclick="location.reload()">
+                <button type="button" class="chr-rc__btn" onclick="location.reload()">
                     Перезагрузить страницу
                 </button>
             </div>

--- a/src/Chronos.Web/Shared/MainLayout.razor
+++ b/src/Chronos.Web/Shared/MainLayout.razor
@@ -22,14 +22,14 @@
             @* Chronos mark — the same clock that stands in for the O of the wordmark in
                Components/Common/Stub.razor and in images/favicon/favicon.svg. Kept inline so
                currentColor picks up the AppBar's text colour, and kept visible below 480px
-               where pet-not-display-on-480 hides the name. *@
-            <svg class="pet-brand-mark ml-3" viewBox="0 0 100 100" aria-hidden="true">
+               where chr-not-display-on-480 hides the name. *@
+            <svg class="chr-brand-mark ml-3" viewBox="0 0 100 100" aria-hidden="true">
                 <circle cx="50" cy="50" r="33" fill="none" stroke="currentColor" stroke-width="8" />
                 <line x1="50" y1="50" x2="50" y2="34" stroke="currentColor" stroke-width="8" stroke-linecap="round" transform="rotate(-60 50 50)" />
                 <line x1="50" y1="50" x2="50" y2="24" stroke="#E3A93B" stroke-width="8" stroke-linecap="round" transform="rotate(60 50 50)" />
                 <circle cx="50" cy="50" r="5" fill="#E3A93B" />
             </svg>
-            <MudText Typo="Typo.h6" Class="ml-2 pet-not-display-on-480">Chronos</MudText>
+            <MudText Typo="Typo.h6" Class="ml-2 chr-not-display-on-480">Chronos</MudText>
             @* Keep in step with GitHub:Releases:Repository in appsettings.json. *@
             <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/tolmachev-pravo/chronos" Target="_blank" />
             <MudTooltip Text="@(_model.Theme.IsDarkMode ? "Dark mode" : "Light mode")">
@@ -64,10 +64,10 @@
         <MudDrawer @bind-Open="@_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
             <NavMenu />
         </MudDrawer>
-        <MudMainContent Style="height: 100vh" Class="pet-fill-height">
+        <MudMainContent Style="height: 100vh" Class="chr-fill-height">
             <AuthorizeView>
                 <Authorized>
-                    <MudElement Class="ma-4 pet-fill-height">
+                    <MudElement Class="ma-4 chr-fill-height">
                         @Body
                     </MudElement>
                 </Authorized>

--- a/src/Chronos.Web/wwwroot/css/custom.css
+++ b/src/Chronos.Web/wwwroot/css/custom.css
@@ -7,7 +7,7 @@
     width: 110px;
 }
 
-.pet-vertical-align-middle {
+.chr-vertical-align-middle {
     vertical-align: middle
 }
 
@@ -15,14 +15,14 @@
     font-size: 0.9rem !important;
 }
 
-.pet-horizontal-center {
+.chr-horizontal-center {
     display: block;
     margin-left: auto;
     margin-right: auto;
     text-align: center;
 }
 
-.pet-vertical-center {
+.chr-vertical-center {
     position: relative;
     top: 50%;
     transform: translateY(-50%);
@@ -35,14 +35,14 @@
  * by default (content-height, top-aligned); a page that wants to fill the
  * viewport opts in by adding `flex-grow-1` to its own root (see WorklogListPage).
  */
-.pet-fill-height {
+.chr-fill-height {
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
     min-height: 0;
 }
 
-.pet-white {
+.chr-white {
     color: white !important;
 }
 
@@ -50,30 +50,30 @@
     --mud-drawer-width-left: 180px !important;
 }
 
-.pet-not-display-on-600 {
+.chr-not-display-on-600 {
 }
 
-.pet-not-display-on-480 {
+.chr-not-display-on-480 {
 }
 
 /*
  * Chronos mark in the AppBar (issue #226). Inlined in MainLayout rather than loaded as an
  * <img> so `currentColor` resolves against the AppBar's own text colour — an SVG in an <img>
  * is an isolated document and would fall back to black. Deliberately NOT tagged with
- * pet-not-display-on-480: below 480px the name is hidden and the mark is all that carries
+ * chr-not-display-on-480: below 480px the name is hidden and the mark is all that carries
  * the brand, so it has to survive on its own.
  */
-.pet-brand-mark {
+.chr-brand-mark {
     width: 28px;
     height: 28px;
     flex: none;
 }
 
-.pet-worklog-day-chips-container {
+.chr-worklog-day-chips-container {
     width: 375px
 }
 
-.pet-worklog-day-item-dialog {
+.chr-worklog-day-item-dialog {
     width: 475px
 }
 
@@ -81,21 +81,21 @@
 }
 
 @media (max-width:480px) { /* smartphones, Android phones, landscape iPhone */
-    .pet-not-display-on-480 {
+    .chr-not-display-on-480 {
         display: none;
     }
 
-    .pet-worklog-day-chips-container {
+    .chr-worklog-day-chips-container {
         width: 300px
     }
 
-    .pet-worklog-day-item-dialog {
+    .chr-worklog-day-item-dialog {
         width: 300px
     }
 }
 
 @media (max-width:600px) { /* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones (Android) */
-    .pet-not-display-on-600 {
+    .chr-not-display-on-600 {
         display: none;
     }
 }
@@ -246,7 +246,7 @@
    Features section ("Новинки") — reuses the .extv-glow card
    language; only the feature-specific bits live here.
    ============================================================ */
-.pet-section-head {
+.chr-section-head {
     max-width: 720px;
 }
 .feat-card {
@@ -506,7 +506,7 @@
 
 /* Tooltip markdown (ComponentMarkdownViewer). Scoped to a custom class so it
    does not leak to other .mud-markdown-body content on the page. */
-.pet-component-markdown .mud-markdown-body p {
+.chr-component-markdown .mud-markdown-body p {
     margin-bottom: 0em !important;
     text-align: left !important;
     font-size: small !important;
@@ -636,7 +636,7 @@
     font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
-    animation: pet-rc-fade .2s ease both;
+    animation: chr-rc-fade .2s ease both;
 }
 /* body-scoped + !important to outrank MudBlazor's background-color:!important,
    so the overlay dims the page instead of filling it solid. */
@@ -657,7 +657,7 @@ body #components-reconnect-modal {
     pointer-events: none;
 }
 
-.pet-rc__dialog {
+.chr-rc__dialog {
     width: 100%;
     max-width: 380px;
     padding: 32px 28px;
@@ -667,28 +667,28 @@ body #components-reconnect-modal {
     color: var(--mud-palette-text-primary);
     border: 1px solid var(--mud-palette-lines-default);
     box-shadow: 0 24px 60px -18px rgba(0, 0, 0, .5);
-    animation: pet-rc-pop .25s cubic-bezier(.2,.7,.2,1) both;
+    animation: chr-rc-pop .25s cubic-bezier(.2,.7,.2,1) both;
 }
 
 /* Show only the block for the current class; 'failed' and 'rejected' share the
    reload block (both mean state is unrecoverable). */
-.pet-rc__state { display: none; }
-#components-reconnect-modal.components-reconnect-show .pet-rc__state--show { display: block; }
-#components-reconnect-modal.components-reconnect-failed .pet-rc__state--reload,
-#components-reconnect-modal.components-reconnect-rejected .pet-rc__state--reload { display: block; }
+.chr-rc__state { display: none; }
+#components-reconnect-modal.components-reconnect-show .chr-rc__state--show { display: block; }
+#components-reconnect-modal.components-reconnect-failed .chr-rc__state--reload,
+#components-reconnect-modal.components-reconnect-rejected .chr-rc__state--reload { display: block; }
 
-.pet-rc__title {
+.chr-rc__title {
     margin: 18px 0 8px;
     font-size: 1.15rem;
     font-weight: 600;
 }
-.pet-rc__text {
+.chr-rc__text {
     margin: 0;
     font-size: .9rem;
     line-height: 1.5;
     color: var(--mud-palette-text-secondary);
 }
-.pet-rc__attempt {
+.chr-rc__attempt {
     display: block;
     margin-top: 10px;
     font-size: .8rem;
@@ -696,17 +696,17 @@ body #components-reconnect-modal {
     opacity: .8;
 }
 
-.pet-rc__spinner {
+.chr-rc__spinner {
     width: 52px;
     height: 52px;
     margin: 0 auto;
     border-radius: 50%;
     border: 4px solid rgba(var(--mud-palette-primary-rgb), .18);
     border-top-color: var(--mud-palette-primary);
-    animation: pet-rc-spin .8s linear infinite;
+    animation: chr-rc-spin .8s linear infinite;
 }
 
-.pet-rc__icon {
+.chr-rc__icon {
     display: grid;
     place-items: center;
     width: 52px;
@@ -720,7 +720,7 @@ body #components-reconnect-modal {
 }
 
 /* id-scoped to beat MudBlazor's own button rule (uppercase + 40px auto margin). */
-#components-reconnect-modal .pet-rc__btn {
+#components-reconnect-modal .chr-rc__btn {
     display: block;
     margin: 22px auto 0 !important;
     padding: 10px 26px;
@@ -737,22 +737,22 @@ body #components-reconnect-modal {
     transition: background-color .2s ease, box-shadow .2s ease, transform .1s ease;
     box-shadow: 0 8px 20px -8px rgba(var(--mud-palette-primary-rgb), .8);
 }
-#components-reconnect-modal .pet-rc__btn:hover {
+#components-reconnect-modal .chr-rc__btn:hover {
     background: var(--mud-palette-primary-darken);
     box-shadow: 0 10px 26px -8px rgba(var(--mud-palette-primary-rgb), .9);
 }
-#components-reconnect-modal .pet-rc__btn:active { transform: translateY(1px); }
+#components-reconnect-modal .chr-rc__btn:active { transform: translateY(1px); }
 
-@keyframes pet-rc-spin { to { transform: rotate(360deg); } }
-@keyframes pet-rc-fade { from { opacity: 0; } to { opacity: 1; } }
-@keyframes pet-rc-pop {
+@keyframes chr-rc-spin { to { transform: rotate(360deg); } }
+@keyframes chr-rc-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes chr-rc-pop {
     from { opacity: 0; transform: translateY(12px) scale(.97); }
     to   { opacity: 1; transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
     #components-reconnect-modal,
-    .pet-rc__dialog { animation: none; }
-    .pet-rc__spinner { animation-duration: 2s; }
+    .chr-rc__dialog { animation: none; }
+    .chr-rc__spinner { animation-duration: 2s; }
 }
 

--- a/src/Chronos.Web/wwwroot/css/site.css
+++ b/src/Chronos.Web/wwwroot/css/site.css
@@ -151,10 +151,10 @@ app {
 }
 
 :root {
-    --pet-logged-opacity: 0.55;
+    --chr-logged-opacity: 0.55;
 }
 
-.pet-day-header {
+.chr-day-header {
     display: flex;
     align-items: center;
     gap: 16px;
@@ -163,51 +163,51 @@ app {
     background: var(--mud-palette-background-grey);
     border-radius: 0;
 }
-.pet-day-header-done {
+.chr-day-header-done {
     border-left-color: var(--mud-palette-success);
     background: rgba(var(--mud-palette-success-rgb), 0.07);
 }
-.pet-day-header-progress {
+.chr-day-header-progress {
     border-left-color: var(--mud-palette-primary);
     background: rgba(var(--mud-palette-primary-rgb), 0.07);
 }
-.pet-day-header-weekend {
+.chr-day-header-weekend {
     border-left-color: var(--mud-palette-error);
     background: rgba(var(--mud-palette-error-rgb), 0.07);
 }
 
-.pet-day-date { flex-shrink: 0; min-width: 96px; }
-.pet-day-date-main { font-size: 14px; font-weight: 500; line-height: 1.3; }
-.pet-day-date-sub { font-size: 11px; opacity: 0.55; }
-.pet-day-header-weekend .pet-day-date-main,
-.pet-day-header-weekend .pet-day-date-sub { color: var(--mud-palette-error); opacity: 1; }
+.chr-day-date { flex-shrink: 0; min-width: 96px; }
+.chr-day-date-main { font-size: 14px; font-weight: 500; line-height: 1.3; }
+.chr-day-date-sub { font-size: 11px; opacity: 0.55; }
+.chr-day-header-weekend .chr-day-date-main,
+.chr-day-header-weekend .chr-day-date-sub { color: var(--mud-palette-error); opacity: 1; }
 
-.pet-day-progress { flex: 1; min-width: 100px; max-width: 180px; }
-.pet-day-bar-track {
+.chr-day-progress { flex: 1; min-width: 100px; max-width: 180px; }
+.chr-day-bar-track {
     height: 4px;
     background: var(--mud-palette-divider);
     border-radius: 2px;
     overflow: hidden;
     margin-bottom: 4px;
 }
-.pet-day-bar-fill { height: 100%; border-radius: 2px; background: var(--mud-palette-divider); }
-.pet-day-header-done .pet-day-bar-fill { background: var(--mud-palette-success); }
-.pet-day-header-progress .pet-day-bar-fill { background: var(--mud-palette-primary); }
-.pet-day-header-weekend .pet-day-bar-fill { background: var(--mud-palette-error); }
+.chr-day-bar-fill { height: 100%; border-radius: 2px; background: var(--mud-palette-divider); }
+.chr-day-header-done .chr-day-bar-fill { background: var(--mud-palette-success); }
+.chr-day-header-progress .chr-day-bar-fill { background: var(--mud-palette-primary); }
+.chr-day-header-weekend .chr-day-bar-fill { background: var(--mud-palette-error); }
 
-.pet-day-bar-label {
+.chr-day-bar-label {
     font-size: 11px;
     display: flex;
     justify-content: space-between;
     opacity: 0.65;
 }
-.pet-day-bar-pct { font-weight: 500; }
+.chr-day-bar-pct { font-weight: 500; }
 
-.pet-day-metrics { display: flex; gap: 12px; align-items: center; flex-shrink: 0; }
-.pet-day-metric { display: flex; align-items: center; gap: 4px; font-size: 13px; }
-.pet-day-metric-val { font-weight: 500; }
-.pet-day-metric-lbl { font-size: 11px; opacity: 0.6; }
-.pet-day-sep { opacity: 0.3; font-size: 18px; line-height: 1; }
+.chr-day-metrics { display: flex; gap: 12px; align-items: center; flex-shrink: 0; }
+.chr-day-metric { display: flex; align-items: center; gap: 4px; font-size: 13px; }
+.chr-day-metric-val { font-weight: 500; }
+.chr-day-metric-lbl { font-size: 11px; opacity: 0.6; }
+.chr-day-sep { opacity: 0.3; font-size: 18px; line-height: 1; }
 
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Последний слой ребрендинга из issue #226. Стек поверх #274.

133 вхождения 51 имени класса и `@keyframes` в 22 файлах, все приватные для приложения. Поведение не меняется.

## Ловушка, которую пришлось обойти

`pet-` встречался не только в CSS: в `deploy-iis.yml` это `pet-jira-copilot-` — fallback-кандидат из #274. Сплошная замена сломала бы деплой уже опубликованных релизов. Замена ограничена `src/`, предварительно проверено, что строки `pet-jira-copilot` там нет вообще.

## Проверено

Тот же инвариант, что в #272: каждый из 22 файлов отличается от прежнего содержимого **ровно** этой заменой, 0 файлов с посторонними правками, BOM сохранён (14 файлов с ним). Множества имён сверены поштучно — 51 к 51, ни одного расхождения в обе стороны.

Переименовались и имена `@keyframes`, поэтому ссылки в `animation:` и сами блоки должны были поехать синхронно. Самая хрупкая пара здесь — модалка переподключения: разметка в `_Host.cshtml`, стили в `custom.css`. Уронил сервер с открытой страницей и проверил в живую: диалог отрисован (белый фон, радиус 18px, заголовок, счётчик попыток), спиннер 52×52 с анимацией, которая резолвится в `chr-rc-spin`.

На `/worklogs`, `/extensions`, `/features` и `/releases` прогнана проверка «каждый `chr-` класс в DOM имеет правило в CSS» — ни одного неопределённого, `pet-` в DOM не осталось. На 375px `chr-not-display-on-480` по-прежнему скрывает название приложения.

Сборка чистая, 133 теста, логи сервера без ошибок.

## Попутно

Исправлена опечатка в имени приватного класса: `pet-backgorund-container` → `chr-background-container`. Определение и единственное использование лежат в одном файле.

После мерджа единственное упоминание старого имени в репозитории — `pet-jira-copilot-` в fallback деплоя, и оно там намеренно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)