### PR TITLE
Актуальное описание приложения: README и баннер

### DIFF
--- a/.github/images/banner.svg
+++ b/.github/images/banner.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 240" width="880" height="240"
+     role="img" aria-labelledby="chronos-banner-title">
+    <title id="chronos-banner-title">Chronos — подсказывает, сколько времени и на какие задачи списать в Jira</title>
+    <!--
+        README banner (issue #254). The wordmark is the one the app itself shows on empty states
+        and 404: CHRON, a live clock in place of the O, then S — see
+        src/Chronos.Web/Components/Common/Stub.razor. Same ring, same gold minute hand sweeping in
+        8s, same slow hour hand and gold centre pin as the app icon in
+        wwwroot/images/favicon/favicon.svg. Strokes are a touch heavier than in the app: the mark
+        is drawn far larger here, and the thin ring reads as weak next to 78px letters.
+
+        Two constraints shape this file, both coming from how GitHub renders it:
+
+        1. It is served as an image, so there is no page CSS and no MudBlazor theme. Colours are
+           literal, and the purple panel makes the banner readable on both the light and the dark
+           GitHub theme without a prefers-color-scheme variant.
+        2. The viewer's font is unknown — Roboto is not there to measure. So CHRON is anchored at
+           its end and S at its start against the fixed clock box: whatever the real letter widths
+           turn out to be, the letters always butt against the clock instead of overlapping it.
+           Only the outer edges of the word shift, which is invisible at this size.
+
+        Note for editors: this is XML, so a comment may not contain a double hyphen.
+    -->
+    <defs>
+        <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#6E5DF0" />
+            <stop offset="1" stop-color="#4433C9" />
+        </linearGradient>
+        <radialGradient id="glow" cx="0.18" cy="0.1" r="0.9">
+            <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.18" />
+            <stop offset="1" stop-color="#FFFFFF" stop-opacity="0" />
+        </radialGradient>
+    </defs>
+
+    <style>
+        .wm {
+            font-family: "Roboto", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            font-weight: 800;
+            font-size: 78px;
+            letter-spacing: 12px;
+            fill: #FFFFFF;
+        }
+        .tagline {
+            font-family: "Roboto", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            font-weight: 400;
+            font-size: 21px;
+            letter-spacing: 0.6px;
+            fill: #FFFFFF;
+            fill-opacity: 0.8;
+        }
+        .ring { fill: none; stroke: #FFFFFF; stroke-width: 10; }
+        .hand { stroke-width: 8.5; stroke-linecap: round; transform-origin: 50px 50px; }
+        .hour { stroke: #FFFFFF; animation: sweep 48s linear infinite; }
+        .min { stroke: #E3A93B; animation: sweep 8s linear infinite; }
+        .pin { fill: #E3A93B; }
+
+        @keyframes sweep { to { transform: rotate(360deg); } }
+
+        @media (prefers-reduced-motion: reduce) {
+            .hour, .min { animation: none; }
+        }
+    </style>
+
+    <rect width="880" height="240" rx="30" fill="url(#panel)" />
+    <rect width="880" height="240" rx="30" fill="url(#glow)" />
+
+    <text class="wm" x="540" y="116" text-anchor="end">CHRON</text>
+    <!--
+        80px box for the clock: that is 1.02em, the width the O clock has in the app's wordmark,
+        and it centres the ring on the cap height of the letters. Offsets on both sides are about
+        one tracking step, matching the gap CHRON's trailing letter-spacing leaves on the left.
+    -->
+    <g transform="translate(537.6 48.5) scale(0.8)">
+        <circle class="ring" cx="50" cy="50" r="42" />
+        <!--
+            Static 10:10 offsets live on wrapper groups, not on the hands themselves: a CSS
+            animation replaces an element's own transform, so an offset written on the line would
+            be dropped the moment the sweep starts. The offsets also keep the hands apart where
+            the animation never runs (prefers-reduced-motion), instead of stacking them into what
+            reads as a single stroke.
+        -->
+        <g transform="rotate(-60 50 50)">
+            <line class="hand hour" x1="50" y1="50" x2="50" y2="30" />
+        </g>
+        <g transform="rotate(60 50 50)">
+            <line class="hand min" x1="50" y1="50" x2="50" y2="16" />
+        </g>
+        <circle class="pin" cx="50" cy="50" r="7" />
+    </g>
+    <text class="wm" x="627" y="116" text-anchor="start">S</text>
+
+    <text class="tagline" x="440" y="173" text-anchor="middle">Подсказывает, сколько времени и на какие задачи списать в Jira</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,39 +1,145 @@
-# Chronos
+<p align="center">
+  <img src=".github/images/banner.svg" alt="Chronos" width="880">
+</p>
 
-Chronos is an application designed to simplify and automate the process of filling out Jira worklogs. It allows users to log their work time more efficiently and effortlessly.
+<p align="center">
+  <a href="https://github.com/tolmachev-pravo/chronos/actions/workflows/dotnet.yml"><img src="https://github.com/tolmachev-pravo/chronos/actions/workflows/dotnet.yml/badge.svg" alt=".NET"></a>
+  <a href="https://github.com/tolmachev-pravo/chronos/releases"><img src="https://img.shields.io/github/v/release/tolmachev-pravo/chronos?sort=semver" alt="Release"></a>
+</p>
 
-![image](https://github.com/tolmachev-pravo/chronos/assets/62241382/009697f2-8e71-4473-87a2-0a82c72f6761)
+Chronos — веб-приложение, которое заполняет ворклоги в Jira за вас: собирает вашу активность за период
+и предлагает, сколько времени и на какие задачи списать. Остаётся проверить предложенное и подтвердить.
 
-# Features
-* Seamless integration with Jira for authentication
-* Automatic suggestions for creating worklogs based on your profile settings
-* Customizable profile settings for personalized time management
-* Different color codes for easy identification of suggested worklogs
+## Возможности
 
-# Getting Started
-To use Chronos, you need to have a Jira account. Once you have an account, follow these steps:
+* **Подсказки по списанию времени.** Приложение разбирает вашу активность в Jira за выбранный период и
+  строит список предполагаемых ворклогов по дням — с учётом рабочих часов и обеда.
+* **Четыре источника событий.** Переходы статусов в задачах, где вы исполнитель; задачи, которые вы
+  комментировали; задачи, которые вы тестировали; события из подключённого календаря.
+* **Настройка перед списанием.** Любой предложенный ворклог можно поправить — время и комментарий —
+  прямо перед добавлением в Jira.
+* **Произвольный ворклог.** Время можно списать на любую задачу вручную, через контекстное меню дня.
+* **Extensions.** Раздел, где вы сами решаете, какие источники событий включены: Jira (события
+  исполнителя, комментарии, тестирование — по отдельности) и Яндекс.Календарь. Отключённое не
+  запрашивается из Jira, поэтому поиск за период работает быстрее.
+* **Интеграция с Яндекс.Календарём.** События календаря превращаются в готовые ворклоги: настраиваются
+  логин, пароль приложения, исключаемые фразы и правила сопоставления встреч с задачами.
+* **Два способа входа.** Логин и пароль Jira либо персональный токен (PAT) — токен можно отозвать на
+  стороне Jira в любой момент.
+* **Функции и релизы внутри приложения.** Раздел Features рассказывает, что умеет приложение, раздел
+  Releases показывает историю обновлений — она подтягивается со страницы релизов в GitHub.
+* **Светлая и тёмная темы.** Выбор запоминается для пользователя.
 
-1. Clone the repository to your local machine.
-2. Configure the application settings in the appsettings.json file:
-    * Set the Jira URL.
-    * Specify the list of cached issues (optional).
-    * Configure the Serilog settings (optional).
-3. Build and run the application.
-4. Customize your profile settings:
-    * Set the date range for searching issues to calculate worklogs.
-    * Specify your daily working start and end time.
-    * Define the issue status for when you start working on it.
-    * Set the default time for logging worklogs through comments.
-    * Specify the average lunch break duration.
+## Как это работает
 
+Chronos не ведёт централизованную базу списаний — он читает данные из Jira вашим доступом. В локальной
+SQLite-базе лежат только пользователи и настройки расширений, причём секреты расширений шифруются
+через ASP.NET Core Data Protection. Профиль, выбранная тема и фильтр поиска хранятся в localStorage
+браузера.
 
-# Worklog Suggestions
+Предложенное время — **совещательное**: расчёт приблизительный и опирается на время смены статусов и
+время комментариев. Итоговое решение всегда за вами, а удалить ворклог можно через интерфейс Jira.
 
-Chronos provides a list of suggested worklogs categorized by days. Here's how to interpret the color codes:
+### Легенда списка ворклогов
 
-* Purple: Suggested worklogs for tasks where you are the assignee.
-* Green: Worklogs that are already logged in Jira. If no time is specified, they are associated with the suggested worklog above. If time is specified, they are independent worklogs.
-* Blue: Suggested worklogs for tasks where you have left comments.
+Каждая строка дня — либо предложение, либо уже списанное время. Различать помогают цвет и иконка:
 
-# Contributing
-Contributions are welcome! If you have any suggestions, bug reports, or feature requests, please open an issue or submit a pull request.
+| Вид | Цвет | Иконка | Что это |
+| --- | --- | --- | --- |
+| Предложение по задаче, где вы исполнитель | фиолетовый | задача | построено по переходам статусов |
+| Предложение по задаче, которую вы тестировали | розовый | жук | источник — события тестировщика |
+| Предложение по задаче, которую вы комментировали | синий | комментарий | длительность задаётся в настройках расширения Jira |
+| Событие календаря | бирюзовый | календарь | пришло из Яндекс.Календаря |
+| Фактический ворклог | бирюзовый | галочка | уже списано в Jira |
+
+Полоса прогресса в заголовке дня показывает, сколько времени уже списано от нормы дня.
+
+## Запуск локально
+
+Нужен [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) и доступ к Jira.
+
+1. Клонируйте репозиторий.
+2. Проверьте `src/Chronos.Web/appsettings.json`:
+   * `Jira:Url` — адрес вашей Jira;
+   * `Jira:Tempo:Enabled` и `Jira:ScriptRunner:Enabled` — включены ли эти плагины в вашей Jira;
+   * `Jira:CachedIssues` — задачи, которые всегда под рукой в меню (необязательно);
+   * `GitHub:Releases` — репозиторий и параметры кеша для раздела Releases (необязательно);
+   * `Serilog` — логирование, по умолчанию в `logs/log-<дата>.txt` (необязательно).
+3. Запустите приложение:
+
+```bash
+dotnet run --project src/Chronos.Web
+```
+
+Миграции базы применяются при старте автоматически. Доступны также `/health` и `/healthchecks-ui`
+для проверки состояния и `/swagger` для API.
+
+### Режим без Jira
+
+Для разработки интерфейса есть мок-режим: данные генерируются, любой логин проходит, обращений к
+реальной Jira нет.
+
+```bash
+ASPNETCORE_IS_MOCK=true dotnet run --project src/Chronos.Web
+```
+
+В Windows PowerShell:
+
+```powershell
+$env:ASPNETCORE_IS_MOCK = "true"; dotnet run --project src/Chronos.Web
+```
+
+### Настройки поиска
+
+На странице Worklogs задаются период, начало и конец рабочего дня и длительность обеда — от них
+зависит, как распределяется время по дням. Что именно собирать из Jira, настраивается в Extensions.
+
+## Архитектура
+
+Clean Architecture, четыре проекта:
+
+| Проект | Назначение |
+| --- | --- |
+| [Chronos.Domain](src/Chronos.Domain) | сущности и модели предметной области, без зависимостей |
+| [Chronos.Application](src/Chronos.Application) | сценарии на MediatR, интерфейсы хранилищ, распределение времени по дням |
+| [Chronos.Infrastructure](src/Chronos.Infrastructure) | Jira (Atlassian.SDK, Tempo, ScriptRunner), CalDAV Яндекс.Календаря, EF Core + SQLite, шифрование секретов, мок-слой |
+| [Chronos.Web](src/Chronos.Web) | Blazor Server + MudBlazor, страницы, компоненты, авторизация по cookie |
+
+Хранилища трёхуровневые: `IMemoryCache` → `ILocalStorage` (браузер) → `IDataSource` (Jira), общая
+точка входа — `IStorage`. Подробнее — в [development.readme.md](src/Chronos.Web/development.readme.md).
+
+## Разработка
+
+```bash
+dotnet build Chronos.sln
+dotnet test
+```
+
+Юнит-тесты — [tests/Chronos.UnitTests](tests/Chronos.UnitTests), запускаются в CI на каждый push и PR
+в `master` ([.NET](.github/workflows/dotnet.yml)).
+
+Миграции EF Core создаются из папки `src/Chronos.Infrastructure`:
+
+```bash
+dotnet ef migrations add Migration_Name --startup-project ../Chronos.Web --context ApplicationDbContext
+```
+
+## Релизы
+
+Версия приложения выводится из git-тегов через MinVer: на теге `v1.8.0` сборка получает версию
+`1.8.0`, между тегами — `1.8.1-alpha.0.N`. Push тега `v*` запускает
+[Release](.github/workflows/release.yml): собирается и тестируется артефакт, публикуется релиз с
+заметками; публикация релиза запускает деплой на IIS
+([Deploy to IIS](.github/workflows/deploy-iis.yml)). Текущая версия видна в левом меню приложения и
+ведёт в раздел Releases.
+
+Описания новых возможностей живут в
+[wwwroot/documents/features](src/Chronos.Web/wwwroot/documents/features) — по папке на функцию
+(`index.md`, `preview.md`, `metadata.json`) — и показываются в разделе Features и в виджете «Что
+нового» на странице ворклогов.
+
+## Обратная связь
+
+Пожелания, идеи и баги — в [Issues](https://github.com/tolmachev-pravo/chronos/issues) или
+[Discussions](https://github.com/tolmachev-pravo/chronos/discussions). Pull request'ы тоже
+приветствуются.


### PR DESCRIPTION
Closes #254

README описывал ещё `pet-jira-copilot`: без Extensions, Яндекс.Календаря, разделов Features и Releases и без входа по токену. Переписан на русском — на языке, на котором уже написаны интерфейс, релизные заметки и описания функций.

### Что изменилось

* **README переписан по коду, а не по старому тексту.** Возможности, легенда списка, запуск локально, мок-режим, архитектура, тесты, релизы и версионирование через MinVer.
* **Легенда цветов исправлена** — источников четыре, а не три: фиолетовый (исполнитель), розовый (тестирование), синий (комментарии), бирюзовый (события календаря и фактические ворклоги, различаются иконкой). Сверено с `Components/Worklogs/WorklogItem.razor.cs`.
* **Уточнено, где лежат данные:** в SQLite — пользователи и настройки расширений с зашифрованными секретами, в localStorage браузера — профиль, тема и фильтр поиска.
* **Скриншот заменён баннером на SVG** — тем же знаком, что приложение показывает на пустых состояниях и 404: часы вместо буквы O, минутная стрелка идёт за 8 секунд. Баннер не устаревает с изменением интерфейса и не требует данных Jira.

### Про баннер

* Своя фиолетовая подложка — читается и на светлой, и на тёмной теме GitHub, без варианта под `prefers-color-scheme`.
* Статичное положение стрелок 10:10 сохранено: там, где `prefers-reduced-motion` выключает анимацию, стрелки не сливаются в одну черту.
* `CHRON` прижат концом, `S` началом к фиксированному боксу часов — шрифт у читателя неизвестен, и при любой его ширине буквы не наезжают на знак.
* Лежит в `.github/images`, потому что `docs/` в .gitignore.

### Проверка

Баннер отдан работающим приложением и проверен в браузере: файл парсится, анимация идёт 8 секунд с центром вращения на оси стрелок, кольцо центрировано по высоте заглавных букв, зазоры слева и справа от часов совпадают с межбуквенным интервалом.

### Метаданные репозитория

Описание в About было пустым — заполнено, topics расширены: `worklog`, `time-tracking`, `blazor`, `blazor-server`, `mudblazor`, `dotnet`, `csharp` в дополнение к `jira`.

### Проверено на GitHub

README ветки открыт в браузере: баннер отдаётся (880×240), бейджи грузятся, разделы рендерятся, стрелки часов идут — за 2 секунды минутная уходит примерно на 90°.
